### PR TITLE
Fix v2 deposit cap boundary handling and add explicit cap error

### DIFF
--- a/contracts/bitflow-vault-core-v2.clar
+++ b/contracts/bitflow-vault-core-v2.clar
@@ -33,6 +33,7 @@
 (define-constant ERR-ZERO-AMOUNT (err u119))
 (define-constant ERR-INVALID-PARAM (err u120))
 (define-constant ERR-INSUFFICIENT-LIQUIDITY (err u121))
+(define-constant ERR-DEPOSIT-CAP-EXCEEDED (err u401))
 
 ;; ===== TUNABLE PROTOCOL PARAMETERS =====
 (define-data-var min-collateral-ratio uint u150)

--- a/contracts/bitflow-vault-core-v2.clar
+++ b/contracts/bitflow-vault-core-v2.clar
@@ -494,7 +494,7 @@
     (asserts! (not (var-get is-paused)) ERR-PROTOCOL-PAUSED)
     (asserts! (var-get deposits-enabled) ERR-PROTOCOL-PAUSED)
     (asserts! (> amount u0) ERR-ZERO-AMOUNT)
-    (asserts! (< amount DEPOSIT-LIMIT) ERR-INSUFFICIENT-BALANCE)
+    (asserts! (<= amount DEPOSIT-LIMIT) ERR-INSUFFICIENT-BALANCE)
     
     (let (
       (current-deposit (default-to u0 (map-get? user-deposits tx-sender)))

--- a/contracts/bitflow-vault-core-v2.clar
+++ b/contracts/bitflow-vault-core-v2.clar
@@ -500,7 +500,7 @@
       (current-deposit (default-to u0 (map-get? user-deposits tx-sender)))
       (new-deposit (safe-add current-deposit amount))
     )
-      (asserts! (<= new-deposit DEPOSIT-LIMIT) ERR-INSUFFICIENT-BALANCE)
+      (asserts! (<= new-deposit DEPOSIT-LIMIT) ERR-DEPOSIT-CAP-EXCEEDED)
       
       ;; Transfer STX from user to contract
       (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))

--- a/contracts/bitflow-vault-core-v2.clar
+++ b/contracts/bitflow-vault-core-v2.clar
@@ -494,7 +494,7 @@
     (asserts! (not (var-get is-paused)) ERR-PROTOCOL-PAUSED)
     (asserts! (var-get deposits-enabled) ERR-PROTOCOL-PAUSED)
     (asserts! (> amount u0) ERR-ZERO-AMOUNT)
-    (asserts! (<= amount DEPOSIT-LIMIT) ERR-INSUFFICIENT-BALANCE)
+    (asserts! (<= amount DEPOSIT-LIMIT) ERR-DEPOSIT-CAP-EXCEEDED)
     
     (let (
       (current-deposit (default-to u0 (map-get? user-deposits tx-sender)))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Oracle registry now rejects `submit-price` updates when reporter count is below configured `min-reporters`
 - Vault v2 now uses a shared `calculate-outstanding-debt` path for health-factor, repayment quotes, and repay execution to eliminate debt drift
+- Vault v2 deposit cap enforcement now treats `DEPOSIT-LIMIT` as an inclusive upper bound and returns `u401` only when a deposit exceeds the cap
 
 ### Security
 - Added reporter-threshold enforcement error path (`u400`) to prevent under-quorum aggregate updates

--- a/docs/ERROR_REFERENCE.md
+++ b/docs/ERROR_REFERENCE.md
@@ -20,6 +20,7 @@ Contract: `SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193.bitflow-vault-core-v2`
 | `u109` | `ERR-OWNER-ONLY` | `initialize` | Caller is not the contract owner |
 | `u110` | `ERR-INVALID-RATE` | `borrow` | Interest rate exceeds 10000 BPS (100%) |
 | `u111` | `ERR-INVALID-TERM` | `borrow` | Term is less than 1 day or more than 365 days |
+| `u401` | `ERR-DEPOSIT-CAP-EXCEEDED` | `deposit` | Deposit would exceed per-user cap (10M STX) |
 
 > **Note**: Error code `u104` is not used in the current contract version.
 
@@ -218,6 +219,23 @@ Result: (err u105) — need 2 more STX
 
 ---
 
+### u401 — ERR-DEPOSIT-CAP-EXCEEDED
+
+**Function**: `deposit`
+
+**Cause**: The resulting user deposit would exceed `DEPOSIT-LIMIT` (`u10_000_000_000_000`).
+
+**Clarity source**:
+```clarity
+(asserts! (<= new-deposit DEPOSIT-LIMIT) (err u401))
+```
+
+**Resolution**:
+1. Reduce the deposit amount so `current-deposit + amount <= DEPOSIT-LIMIT`
+2. Use `get-user-deposit` to calculate remaining capacity before submitting
+
+---
+
 ## Error Handling in Code
 
 ### TypeScript
@@ -257,7 +275,7 @@ function handleContractError(errorCode: number): string {
 
 | Function | Possible Errors |
 |----------|----------------|
-| `deposit` | u102 |
+| `deposit` | u102, u401 |
 | `withdraw` | u101, u102 |
 | `borrow` | u102, u103, u105, u110, u111 |
 | `repay` | u106 |

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -129,6 +129,7 @@ Some wallet extensions require re-authentication after a page refresh.
 | v1 deposit no cap | v2.0.0 | Added per-user deposit cap (10M STX) to v1 deposit function |
 | Oracle min-reporters lock | v2.0.0 | Prevented setting min-reporters above current reporter count |
 | Collateral withdrawal lock | v2.0.0 | v2 allows partial withdrawal of excess collateral |
+| v2 deposit cap boundary off-by-one | v2.0.1 | Exact-cap deposits are accepted; only above-cap deposits return `u401` |
 
 ---
 

--- a/tests/bitflow-vault-core-v2.boundary.test.ts
+++ b/tests/bitflow-vault-core-v2.boundary.test.ts
@@ -72,7 +72,7 @@ describe("bitflow-vault-core-v2 boundary tests", () => {
       setup();
       // DEPOSIT-LIMIT is 10M STX = 10_000_000_000_000 microSTX
       const { result } = deposit(10_000_000_000_001, wallet1());
-      expect(result).toBeErr(Cl.uint(101)); // ERR-INSUFFICIENT-BALANCE
+      expect(result).toBeErr(Cl.uint(401)); // ERR-DEPOSIT-CAP-EXCEEDED
     });
   });
 

--- a/tests/bitflow-vault-core-v2.boundary.test.ts
+++ b/tests/bitflow-vault-core-v2.boundary.test.ts
@@ -75,6 +75,12 @@ describe("bitflow-vault-core-v2 boundary tests", () => {
       expect(result).toBeOk(Cl.bool(true));
     });
 
+    it("accepts deposit one unit below DEPOSIT-LIMIT", () => {
+      setup();
+      const { result } = deposit(DEPOSIT_LIMIT - 1, wallet1());
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
     it("rejects deposit exceeding per-user limit", () => {
       setup();
       // DEPOSIT-LIMIT is 10M STX = 10_000_000_000_000 microSTX

--- a/tests/bitflow-vault-core-v2.boundary.test.ts
+++ b/tests/bitflow-vault-core-v2.boundary.test.ts
@@ -2,6 +2,7 @@ import { Cl } from "@stacks/transactions";
 import { describe, expect, it } from "vitest";
 
 const CONTRACT = "bitflow-vault-core-v2";
+const DEPOSIT_LIMIT = 10_000_000_000_000;
 
 describe("bitflow-vault-core-v2 boundary tests", () => {
   const getAccounts = () => simnet.getAccounts();

--- a/tests/bitflow-vault-core-v2.boundary.test.ts
+++ b/tests/bitflow-vault-core-v2.boundary.test.ts
@@ -81,10 +81,9 @@ describe("bitflow-vault-core-v2 boundary tests", () => {
       expect(result).toBeOk(Cl.bool(true));
     });
 
-    it("rejects deposit exceeding per-user limit", () => {
+    it("rejects deposit one unit above DEPOSIT-LIMIT", () => {
       setup();
-      // DEPOSIT-LIMIT is 10M STX = 10_000_000_000_000 microSTX
-      const { result } = deposit(10_000_000_000_001, wallet1());
+      const { result } = deposit(DEPOSIT_LIMIT + 1, wallet1());
       expect(result).toBeErr(Cl.uint(401)); // ERR-DEPOSIT-CAP-EXCEEDED
     });
   });

--- a/tests/bitflow-vault-core-v2.boundary.test.ts
+++ b/tests/bitflow-vault-core-v2.boundary.test.ts
@@ -69,6 +69,12 @@ describe("bitflow-vault-core-v2 boundary tests", () => {
       expect(result).toBeOk(Cl.bool(true));
     });
 
+    it("accepts deposit exactly at DEPOSIT-LIMIT", () => {
+      setup();
+      const { result } = deposit(DEPOSIT_LIMIT, wallet1());
+      expect(result).toBeOk(Cl.bool(true));
+    });
+
     it("rejects deposit exceeding per-user limit", () => {
       setup();
       // DEPOSIT-LIMIT is 10M STX = 10_000_000_000_000 microSTX

--- a/tests/bitflow-vault-core-v2.deposit-limits.test.ts
+++ b/tests/bitflow-vault-core-v2.deposit-limits.test.ts
@@ -68,12 +68,10 @@ describe("bitflow-vault-core-v2 deposit limit enforcement", () => {
   // ── Per-user cap rejects oversized single deposit ─────────────
   it("rejects single deposit exceeding DEPOSIT-LIMIT", () => {
     init();
-    // DEPOSIT-LIMIT = 10_000_000_000_000 (10M STX in microSTX)
     const { result } = simnet.callPublicFn(
-      CONTRACT, "deposit", [Cl.uint(10_000_000_000_001)], wallet1()
+      CONTRACT, "deposit", [Cl.uint(DEPOSIT_LIMIT + 1)], wallet1()
     );
-    // Should fail: amount >= DEPOSIT-LIMIT
-    expect(result).toBeErr(expect.anything());
+    expect(result).toBeErr(Cl.uint(401));
   });
 
   // ── Per-user cap rejects accumulated deposits over limit ──────

--- a/tests/bitflow-vault-core-v2.deposit-limits.test.ts
+++ b/tests/bitflow-vault-core-v2.deposit-limits.test.ts
@@ -2,6 +2,7 @@ import { Cl } from "@stacks/transactions";
 import { describe, expect, it } from "vitest";
 
 const CONTRACT = "bitflow-vault-core-v2";
+const DEPOSIT_LIMIT = 10_000_000_000_000;
 
 /**
  * Verifies v2 deposit-limit enforcement: per-user caps, zero-amount

--- a/tests/bitflow-vault-core-v2.deposit-limits.test.ts
+++ b/tests/bitflow-vault-core-v2.deposit-limits.test.ts
@@ -52,6 +52,15 @@ describe("bitflow-vault-core-v2 deposit limit enforcement", () => {
     expect(result).toBeOk(Cl.bool(true));
   });
 
+  it("accepts cumulative deposits that reach DEPOSIT-LIMIT", () => {
+    init();
+    simnet.callPublicFn(CONTRACT, "deposit", [Cl.uint(DEPOSIT_LIMIT - 1)], wallet1());
+    const { result } = simnet.callPublicFn(
+      CONTRACT, "deposit", [Cl.uint(1)], wallet1()
+    );
+    expect(result).toBeOk(Cl.bool(true));
+  });
+
   // ── Multiple deposits accumulate ──────────────────────────────
   it("accumulates multiple deposits for same user", () => {
     init();

--- a/tests/bitflow-vault-core-v2.deposit-limits.test.ts
+++ b/tests/bitflow-vault-core-v2.deposit-limits.test.ts
@@ -86,14 +86,11 @@ describe("bitflow-vault-core-v2 deposit limit enforcement", () => {
   // ── Per-user cap rejects accumulated deposits over limit ──────
   it("rejects cumulative deposit exceeding DEPOSIT-LIMIT", () => {
     init();
-    // Deposit just under the limit
-    simnet.callPublicFn(CONTRACT, "deposit", [Cl.uint(9_999_999_999_990)], wallet1());
-    // Second deposit pushes over
+    simnet.callPublicFn(CONTRACT, "deposit", [Cl.uint(DEPOSIT_LIMIT)], wallet1());
     const { result } = simnet.callPublicFn(
-      CONTRACT, "deposit", [Cl.uint(20)], wallet1()
+      CONTRACT, "deposit", [Cl.uint(1)], wallet1()
     );
-    // new-deposit = 10_000_000_000_010 > DEPOSIT-LIMIT
-    expect(result).toBeErr(expect.anything());
+    expect(result).toBeErr(Cl.uint(401));
   });
 
   // ── Different users have independent caps ─────────────────────

--- a/tests/bitflow-vault-core-v2.deposit-limits.test.ts
+++ b/tests/bitflow-vault-core-v2.deposit-limits.test.ts
@@ -36,6 +36,14 @@ describe("bitflow-vault-core-v2 deposit limit enforcement", () => {
     expect(result).toBeOk(Cl.bool(true));
   });
 
+  it("accepts deposit exactly at DEPOSIT-LIMIT", () => {
+    init();
+    const { result } = simnet.callPublicFn(
+      CONTRACT, "deposit", [Cl.uint(DEPOSIT_LIMIT)], wallet1()
+    );
+    expect(result).toBeOk(Cl.bool(true));
+  });
+
   // ── Multiple deposits accumulate ──────────────────────────────
   it("accumulates multiple deposits for same user", () => {
     init();

--- a/tests/bitflow-vault-core-v2.deposit-limits.test.ts
+++ b/tests/bitflow-vault-core-v2.deposit-limits.test.ts
@@ -44,6 +44,14 @@ describe("bitflow-vault-core-v2 deposit limit enforcement", () => {
     expect(result).toBeOk(Cl.bool(true));
   });
 
+  it("accepts deposit one unit below DEPOSIT-LIMIT", () => {
+    init();
+    const { result } = simnet.callPublicFn(
+      CONTRACT, "deposit", [Cl.uint(DEPOSIT_LIMIT - 1)], wallet1()
+    );
+    expect(result).toBeOk(Cl.bool(true));
+  });
+
   // ── Multiple deposits accumulate ──────────────────────────────
   it("accumulates multiple deposits for same user", () => {
     init();

--- a/tests/bitflow-vault-core-v2.deposit-validation.test.ts
+++ b/tests/bitflow-vault-core-v2.deposit-validation.test.ts
@@ -21,7 +21,7 @@ describe("v2 deposit validation", () => {
     const { result } = simnet.callPublicFn(
       CONTRACT, "deposit", [Cl.uint(10000000000001)], wallet1()
     );
-    expect(result).toBeErr(Cl.uint(101));
+    expect(result).toBeErr(Cl.uint(401));
   });
 
   it("accepts a valid deposit", () => {


### PR DESCRIPTION
Fixes the v2 deposit cap off-by-one boundary behavior so deposits at the exact cap are accepted, while above-cap deposits fail with u401. Also adds boundary regression coverage and documentation updates.