### PR TITLE
Add typed liquidation swap helper for atomic debt repayment

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bitflow-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@bitflowlabs/core-sdk": "^3.1.0",
         "@stacks/connect": "^7.8.0",
         "@stacks/network": "^7.3.1",
         "@stacks/transactions": "^7.3.1",
@@ -111,6 +112,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bitflowlabs/core-sdk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bitflowlabs/core-sdk/-/core-sdk-3.1.0.tgz",
+      "integrity": "sha512-6zBbXPR6WoY1LZBH7L/Nbi7V560EG7LpyQJAW09bIGTUfWFaK5oFqhC3KHqg9/y6c+DjOmKlBtSsYJ6QoHbk3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@stacks/connect": "^7.10.2",
+        "@stacks/network": "^7.0.2",
+        "@stacks/transactions": "^7.0.5",
+        "dotenv": "^16.4.7"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -554,9 +570,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -588,9 +604,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -622,9 +638,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -3588,6 +3604,18 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8055,9 +8083,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -8072,9 +8100,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -8089,9 +8117,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -8106,9 +8134,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -8123,9 +8151,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -8140,9 +8168,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -8157,9 +8185,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -8174,9 +8202,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -8191,9 +8219,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -8208,9 +8236,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -8225,9 +8253,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -8242,9 +8270,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -8259,9 +8287,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -8276,9 +8304,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -8293,9 +8321,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -8310,9 +8338,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -8327,9 +8355,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -8344,9 +8372,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -8361,9 +8389,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -8378,9 +8406,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -8395,9 +8423,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -8412,9 +8440,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -8429,9 +8457,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@bitflowlabs/core-sdk": "^3.1.0",
     "@stacks/connect": "^7.8.0",
     "@stacks/network": "^7.3.1",
     "@stacks/transactions": "^7.3.1",

--- a/frontend/src/utils/__tests__/liquidation-swap.test.ts
+++ b/frontend/src/utils/__tests__/liquidation-swap.test.ts
@@ -6,10 +6,10 @@ const mockGetQuoteForRoute = vi.hoisted(() => vi.fn());
 const mockGetSwapParams = vi.hoisted(() => vi.fn());
 
 vi.mock('@bitflowlabs/core-sdk', () => ({
-  BitflowSDK: vi.fn().mockImplementation(() => ({
-    getQuoteForRoute: mockGetQuoteForRoute,
-    getSwapParams: mockGetSwapParams,
-  })),
+  BitflowSDK: class {
+    getQuoteForRoute = mockGetQuoteForRoute;
+    getSwapParams = mockGetSwapParams;
+  },
 }));
 
 type QuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;

--- a/frontend/src/utils/__tests__/liquidation-swap.test.ts
+++ b/frontend/src/utils/__tests__/liquidation-swap.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { executeLiquidationSwap } from '../liquidation-swap';
+
+const mockGetQuoteForRoute = vi.hoisted(() => vi.fn());
+const mockGetSwapParams = vi.hoisted(() => vi.fn());
+
+vi.mock('@bitflowlabs/core-sdk', () => ({
+  BitflowSDK: vi.fn().mockImplementation(() => ({
+    getQuoteForRoute: mockGetQuoteForRoute,
+    getSwapParams: mockGetSwapParams,
+  })),
+}));
+
+type QuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
+type SwapParamsResult = Awaited<ReturnType<BitflowSDK['getSwapParams']>>;
+
+describe('executeLiquidationSwap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns swap params shape for bundling with liquidation tx', async () => {
+    const quote: QuoteResult = {
+      bestRoute: {
+        route: {
+          dex_path: ['alex'],
+          token_path: ['token-stx', 'token-usda'],
+          postConditions: {},
+          quoteData: {
+            contract: 'SP000.mock-router',
+            function: 'quote',
+            parameters: {},
+          },
+          swapData: {
+            contract: 'SP000.mock-router',
+            function: 'swap',
+            parameters: {},
+          },
+          tokenXDecimals: 6,
+          tokenYDecimals: 6,
+        },
+        quote: 99,
+        params: {},
+        quoteData: {
+          contract: 'SP000.mock-router',
+          function: 'quote',
+          parameters: {},
+        },
+        swapData: {
+          contract: 'SP000.mock-router',
+          function: 'swap',
+          parameters: {},
+        },
+        dexPath: ['alex'],
+        tokenPath: ['token-stx', 'token-usda'],
+        tokenXDecimals: 6,
+        tokenYDecimals: 6,
+      },
+      allRoutes: [],
+      inputData: {
+        tokenX: 'token-stx',
+        tokenY: 'token-usda',
+        amountInput: 125,
+      },
+    };
+
+    const swapParams: SwapParamsResult = {
+      functionArgs: ['arg-1', 'arg-2'],
+      postConditions: ['pc-1'],
+      contractAddress: 'SP000.mock-router',
+      contractName: 'mock-router',
+      functionName: 'swap',
+    };
+
+    mockGetQuoteForRoute.mockResolvedValue(quote);
+    mockGetSwapParams.mockResolvedValue(swapParams);
+
+    const result = await executeLiquidationSwap(
+      'ST1A2B3C4D5E6F7G8H9I0J1K2L3M4N5P6Q7R8S9T',
+      125,
+      0.5
+    );
+
+    expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 125);
+    expect(mockGetSwapParams).toHaveBeenCalledWith(
+      {
+        route: quote.bestRoute?.route,
+        amount: 125,
+        tokenXDecimals: 6,
+        tokenYDecimals: 6,
+      },
+      'ST1A2B3C4D5E6F7G8H9I0J1K2L3M4N5P6Q7R8S9T',
+      0.5
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        functionArgs: expect.any(Array),
+        postConditions: expect.any(Array),
+        contractAddress: expect.any(String),
+        contractName: expect.any(String),
+        functionName: expect.any(String),
+      })
+    );
+  });
+});

--- a/frontend/src/utils/__tests__/liquidation-swap.test.ts
+++ b/frontend/src/utils/__tests__/liquidation-swap.test.ts
@@ -104,4 +104,45 @@ describe('executeLiquidationSwap', () => {
       })
     );
   });
+
+  it('throws when the quote does not include a best route', async () => {
+    const quoteWithoutRoute: QuoteResult = {
+      bestRoute: null,
+      allRoutes: [],
+      inputData: {
+        tokenX: 'token-stx',
+        tokenY: 'token-usda',
+        amountInput: 75,
+      },
+    };
+
+    mockGetQuoteForRoute.mockResolvedValue(quoteWithoutRoute);
+
+    await expect(
+      executeLiquidationSwap(
+        'ST1A2B3C4D5E6F7G8H9I0J1K2L3M4N5P6Q7R8S9T',
+        75,
+        0.5
+      )
+    ).rejects.toThrow('No swap route available for liquidation collateral.');
+
+    expect(mockGetSwapParams).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid sender or amounts before calling SDK', async () => {
+    await expect(executeLiquidationSwap('   ', 75, 0.5)).rejects.toThrow(
+      'senderAddress is required.'
+    );
+
+    await expect(
+      executeLiquidationSwap('ST1A2B3C4D5E6F7G8H9I0J1K2L3M4N5P6Q7R8S9T', 0, 0.5)
+    ).rejects.toThrow('collateralAmount must be a positive number.');
+
+    await expect(
+      executeLiquidationSwap('ST1A2B3C4D5E6F7G8H9I0J1K2L3M4N5P6Q7R8S9T', 75, 0)
+    ).rejects.toThrow('slippage must be a positive number.');
+
+    expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
+    expect(mockGetSwapParams).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -13,3 +13,14 @@ export {
 	RateLimiter,
 	validateHealthFactor,
 } from './validation';
+export {
+	LIQUIDATION_COLLATERAL_TOKEN,
+	LIQUIDATION_DEBT_TOKEN,
+	executeLiquidationSwap,
+	mapQuoteToSwapExecutionData,
+} from './liquidation-swap';
+export type {
+	LiquidationQuoteResult,
+	LiquidationSwapExecutionData,
+	LiquidationSwapParams,
+} from './liquidation-swap';

--- a/frontend/src/utils/liquidation-swap.ts
+++ b/frontend/src/utils/liquidation-swap.ts
@@ -1,0 +1,33 @@
+import { BitflowSDK } from '@bitflowlabs/core-sdk';
+
+export const LIQUIDATION_COLLATERAL_TOKEN = 'token-stx';
+export const LIQUIDATION_DEBT_TOKEN = 'token-usda';
+
+export type LiquidationQuoteResult = Awaited<
+  ReturnType<BitflowSDK['getQuoteForRoute']>
+>;
+
+export type LiquidationSwapExecutionData =
+  Parameters<BitflowSDK['getSwapParams']>[0];
+
+export type LiquidationSwapParams = Awaited<
+  ReturnType<BitflowSDK['getSwapParams']>
+>;
+
+export const mapQuoteToSwapExecutionData = (
+  quote: LiquidationQuoteResult,
+  collateralAmount: number
+): LiquidationSwapExecutionData => {
+  const { bestRoute } = quote;
+
+  if (!bestRoute?.route) {
+    throw new Error('No swap route available for liquidation collateral.');
+  }
+
+  return {
+    route: bestRoute.route,
+    amount: collateralAmount,
+    tokenXDecimals: bestRoute.tokenXDecimals,
+    tokenYDecimals: bestRoute.tokenYDecimals,
+  };
+};

--- a/frontend/src/utils/liquidation-swap.ts
+++ b/frontend/src/utils/liquidation-swap.ts
@@ -14,6 +14,14 @@ export type LiquidationSwapParams = Awaited<
   ReturnType<BitflowSDK['getSwapParams']>
 >;
 
+const bitflow = new BitflowSDK();
+
+const assertPositiveNumber = (value: number, label: string): void => {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a positive number.`);
+  }
+};
+
 export const mapQuoteToSwapExecutionData = (
   quote: LiquidationQuoteResult,
   collateralAmount: number
@@ -30,4 +38,27 @@ export const mapQuoteToSwapExecutionData = (
     tokenXDecimals: bestRoute.tokenXDecimals,
     tokenYDecimals: bestRoute.tokenYDecimals,
   };
+};
+
+export const executeLiquidationSwap = async (
+  senderAddress: string,
+  collateralAmount: number,
+  slippage: number
+): Promise<LiquidationSwapParams> => {
+  if (!senderAddress.trim()) {
+    throw new Error('senderAddress is required.');
+  }
+
+  assertPositiveNumber(collateralAmount, 'collateralAmount');
+  assertPositiveNumber(slippage, 'slippage');
+
+  const quote = await bitflow.getQuoteForRoute(
+    LIQUIDATION_COLLATERAL_TOKEN,
+    LIQUIDATION_DEBT_TOKEN,
+    collateralAmount
+  );
+
+  const swapExecutionData = mapQuoteToSwapExecutionData(quote, collateralAmount);
+
+  return bitflow.getSwapParams(swapExecutionData, senderAddress, slippage);
 };


### PR DESCRIPTION
## Summary
- add a frontend liquidation swap utility that routes seized STX collateral through Bitflow to USDA
- call `getQuoteForRoute('token-stx', 'token-usda', collateralAmount)` and build swap execution data from the best route
- call `getSwapParams(...)` and return transaction-ready args and post conditions for bundling with the liquidate call
- export the helper and associated types via the utils barrel
- add unit tests with a mocked BitflowSDK to validate success and failure paths

## Implementation Notes
- SDK is instantiated with zero config (no API key required for standard usage limits)
- helper performs input validation for sender address, collateral amount, and slippage
- helper throws when no best route is returned

## Testing
- `cd frontend && npm run test -- src/utils/__tests__/liquidation-swap.test.ts`
- `cd frontend && npm run test -- src/utils/__tests__`
- `cd frontend && npm run build`
