### PR TITLE
fix(frontend): warn on oracle price divergence

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -165,6 +165,7 @@ frontend/
 - **Transactions:** Deposit, borrow, repay, and withdraw with post-conditions
 - **Transaction Polling:** Monitor pending transactions until confirmed
 - **Error Handling:** Clear error messages for all failure scenarios
+- **Oracle Sanity Checks:** Warn before borrowing or repaying when the oracle price diverges more than 5% from Bitflow's live STX/USDA quote
 
 ### Performance
 - **Code Splitting:** Separate chunks for React and Stacks libraries

--- a/frontend/src/__tests__/integration.test.tsx
+++ b/frontend/src/__tests__/integration.test.tsx
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { Dashboard } from '../components/Dashboard';
 
 // Hoisted mutable state - accessible from vi.mock factories
 const { mockAuthState, mockVaultState, mockProtocolStatsState } = vi.hoisted(() => ({
@@ -194,8 +195,7 @@ describe('App Integration', () => {
   });
 
   describe('User Flow: New User Landing', () => {
-    it('shows welcome page with connect prompt', async () => {
-      const { Dashboard } = await import('../components/Dashboard');
+    it('shows welcome page with connect prompt', () => {
       render(<Dashboard />);
 
       expect(screen.getByAltText('BitFlow Lend')).toBeInTheDocument();
@@ -203,15 +203,13 @@ describe('App Integration', () => {
       expect(screen.getByText(/Connect your wallet/)).toBeInTheDocument();
     });
 
-    it('shows protocol stats even when disconnected', async () => {
-      const { Dashboard } = await import('../components/Dashboard');
+    it('shows protocol stats even when disconnected', () => {
       render(<Dashboard />);
 
       expect(screen.getAllByText('Protocol Overview').length).toBeGreaterThan(0);
     });
 
-    it('does not show action cards when disconnected', async () => {
-      const { Dashboard } = await import('../components/Dashboard');
+    it('does not show action cards when disconnected', () => {
       render(<Dashboard />);
 
       expect(screen.queryByText('Your Portfolio')).not.toBeInTheDocument();
@@ -230,23 +228,20 @@ describe('App Integration', () => {
       };
     });
 
-    it('shows portfolio and action cards when connected', async () => {
-      const { Dashboard } = await import('../components/Dashboard');
+    it('shows portfolio and action cards when connected', () => {
       render(<Dashboard />);
 
       expect(screen.getByText('Your Portfolio')).toBeInTheDocument();
       expect(screen.getByText('Actions')).toBeInTheDocument();
     });
 
-    it('shows deposit, borrow, and repay cards', async () => {
-      const { Dashboard } = await import('../components/Dashboard');
+    it('shows deposit, borrow, and repay cards', () => {
       render(<Dashboard />);
 
       expect(screen.getByText('Deposit to earn and borrow')).toBeInTheDocument();
     });
 
-    it('shows user portfolio with zero initial values', async () => {
-      const { Dashboard } = await import('../components/Dashboard');
+    it('shows user portfolio with zero initial values', () => {
       render(<Dashboard />);
 
       expect(screen.getByText('Total Deposited')).toBeInTheDocument();
@@ -256,7 +251,7 @@ describe('App Integration', () => {
   });
 
   describe('User Flow: Protocol Stats Loading', () => {
-    it('shows loading state then data', async () => {
+    it('shows loading state then data', () => {
       mockProtocolStatsState.current = {
         stats: null,
         isLoading: true,
@@ -265,13 +260,12 @@ describe('App Integration', () => {
         refresh: vi.fn(),
       };
 
-      const { Dashboard } = await import('../components/Dashboard');
       render(<Dashboard />);
 
       expect(screen.getAllByText('Protocol Overview').length).toBeGreaterThan(0);
     });
 
-    it('shows error state when stats fail', async () => {
+    it('shows error state when stats fail', () => {
       mockProtocolStatsState.current = {
         stats: null,
         isLoading: false,
@@ -280,7 +274,6 @@ describe('App Integration', () => {
         refresh: vi.fn(),
       };
 
-      const { Dashboard } = await import('../components/Dashboard');
       render(<Dashboard />);
 
       expect(screen.getByText('Failed to Load Protocol Stats')).toBeInTheDocument();

--- a/frontend/src/__tests__/integration.test.tsx
+++ b/frontend/src/__tests__/integration.test.tsx
@@ -13,6 +13,10 @@ const { mockAuthState, mockVaultState, mockProtocolStatsState } = vi.hoisted(() 
   mockProtocolStatsState: { current: {} as Record<string, unknown> },
 }));
 
+const { mockOracleSanityState } = vi.hoisted(() => ({
+  mockOracleSanityState: { current: { warning: false, deviation: 0 } },
+}));
+
 // Mocks at module scope (hoisted)
 vi.mock('../hooks/useAuth', () => ({
   useAuth: () => mockAuthState.current,
@@ -54,6 +58,10 @@ vi.mock('../hooks/useStxPrice', () => ({
     lastUpdated: new Date(),
     refresh: vi.fn(),
   }),
+}));
+
+vi.mock('../hooks/useOracleSanityCheck', () => ({
+  useOracleSanityCheck: () => mockOracleSanityState.current,
 }));
 
 vi.mock('../hooks/useSmartPolling', () => ({

--- a/frontend/src/components/BorrowCard.tsx
+++ b/frontend/src/components/BorrowCard.tsx
@@ -3,6 +3,8 @@ import { TrendingUp, AlertCircle, CheckCircle, XCircle, ExternalLink } from 'luc
 import { useAuth } from '../hooks/useAuth';
 import { useVault } from '../hooks/useVault';
 import { useSmartPolling } from '../hooks/useSmartPolling';
+import { useStxPrice } from '../hooks/useStxPrice';
+import { useOracleSanityCheck } from '../hooks/useOracleSanityCheck';
 import { LOAN_TERMS, UserLoan } from '../types/vault';
 import { formatSTX } from '../utils/formatters';
 import { PROTOCOL_CONSTANTS, getExplorerUrl } from '../config/contracts';
@@ -15,6 +17,8 @@ import { calculateHealthFactor, getHealthStatus } from '../utils/calculations';
 export const BorrowCard: React.FC = () => {
   const { address, userSession, refreshBalance } = useAuth();
   const vault = useVault(userSession, address);
+  const { price: stxPrice } = useStxPrice();
+  const oracleSanity = useOracleSanityCheck(stxPrice, 'token-stx');
 
   const [borrowAmount, setBorrowAmount] = useState('');
   const [interestRate, setInterestRate] = useState(10);
@@ -46,6 +50,18 @@ export const BorrowCard: React.FC = () => {
   // Calculate estimated interest
   const estimatedInterest = (amount * (interestRate / 100) * (loanTerm / 365));
   const totalRepayment = amount + estimatedInterest;
+  const oracleWarningBanner = oracleSanity.warning ? (
+    <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-lg" role="alert">
+      <AlertCircle className="text-amber-600 flex-shrink-0 mt-0.5" size={20} />
+      <div className="flex-1">
+        <h4 className="text-sm font-semibold text-amber-900 mb-1">Oracle Price Sanity Warning</h4>
+        <p className="text-xs text-amber-800">
+          The oracle price differs from Bitflow&apos;s live STX/USDA quote by{' '}
+          {(oracleSanity.deviation * 100).toFixed(1)}%. Review the market price before borrowing.
+        </p>
+      </div>
+    </div>
+  ) : null;
 
   const handleBorrow = async () => {
     // Validation
@@ -145,6 +161,8 @@ export const BorrowCard: React.FC = () => {
           </div>
         </div>
 
+        {oracleWarningBanner}
+
         <div className="bg-amber-50/80 rounded-xl p-4 space-y-2 border border-amber-100">
           <div className="flex justify-between">
             <span className="text-sm text-gray-600">Loan Amount:</span>
@@ -179,6 +197,8 @@ export const BorrowCard: React.FC = () => {
           <p className="text-sm text-gray-500">Borrow against your collateral</p>
         </div>
       </div>
+
+      {oracleWarningBanner}
 
       {/* Available Collateral */}
       <div className="bg-gray-50/80 rounded-xl p-4 border border-gray-100">

--- a/frontend/src/components/HealthMonitor.tsx
+++ b/frontend/src/components/HealthMonitor.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../hooks/useAuth';
 import { useVault } from '../hooks/useVault';
 import { useSmartPolling } from '../hooks/useSmartPolling';
 import { useStxPrice } from '../hooks/useStxPrice';
+import { useOracleSanityCheck } from '../hooks/useOracleSanityCheck';
 import { formatSTX } from '../utils/formatters';
 import { PROTOCOL_CONSTANTS } from '../config/contracts';
 import { getHealthStatus } from '../utils/calculations';
@@ -23,6 +24,7 @@ export const HealthMonitor: React.FC = () => {
   const { address, userSession } = useAuth();
   const vault = useVault(userSession, address);
   const { price: stxPrice, lastUpdated: priceUpdated, isStale: priceIsStale } = useStxPrice();
+  const oracleSanity = useOracleSanityCheck(stxPrice, 'token-stx');
 
   const [healthFactor, setHealthFactor] = useState<HealthFactorData | null>(null);
   const [userDeposit, setUserDeposit] = useState<UserDeposit | null>(null);
@@ -70,6 +72,20 @@ export const HealthMonitor: React.FC = () => {
   };
 
   const distanceToLiquidation = getDistanceToLiquidation();
+  const oracleWarningBanner = oracleSanity.warning ? (
+    <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-lg" role="alert">
+      <AlertTriangle className="text-amber-600 flex-shrink-0 mt-0.5" size={20} />
+      <div className="flex-1">
+        <h4 className="text-sm font-semibold text-amber-900 mb-1">
+          Oracle Price Sanity Warning
+        </h4>
+        <p className="text-xs text-amber-800">
+          The oracle price is diverging from Bitflow&apos;s live STX/USDA quote by{' '}
+          {(oracleSanity.deviation * 100).toFixed(1)}%. Verify the price before borrowing or repaying.
+        </p>
+      </div>
+    </div>
+  ) : null;
 
   // No active loan
   if (!activeLoan) {
@@ -84,6 +100,8 @@ export const HealthMonitor: React.FC = () => {
             <p className="text-sm text-gray-500">Your position is healthy</p>
           </div>
         </div>
+
+        {oracleWarningBanner}
 
         <div className="bg-emerald-50/80 rounded-xl p-6 text-center border border-emerald-100">
           <CheckCircle className="mx-auto text-emerald-600 mb-3" size={48} />
@@ -126,6 +144,8 @@ export const HealthMonitor: React.FC = () => {
           <p className="text-sm text-gray-500">Track your position health</p>
         </div>
       </div>
+
+      {oracleWarningBanner}
 
       {/* Health Factor Display */}
       {healthFactor && (

--- a/frontend/src/components/RepayCard.tsx
+++ b/frontend/src/components/RepayCard.tsx
@@ -3,6 +3,8 @@ import { DollarSign, AlertCircle, CheckCircle, XCircle, Clock, ExternalLink } fr
 import { useAuth } from '../hooks/useAuth';
 import { useVault } from '../hooks/useVault';
 import { useSmartPolling } from '../hooks/useSmartPolling';
+import { useStxPrice } from '../hooks/useStxPrice';
+import { useOracleSanityCheck } from '../hooks/useOracleSanityCheck';
 import { formatSTX } from '../utils/formatters';
 import { getExplorerUrl } from '../config/contracts';
 import { RepaymentAmount, UserLoan } from '../types/vault';
@@ -14,6 +16,8 @@ import { RepaymentAmount, UserLoan } from '../types/vault';
 export const RepayCard: React.FC = () => {
   const { address, balanceSTX, userSession } = useAuth();
   const vault = useVault(userSession, address);
+  const { price: stxPrice } = useStxPrice();
+  const oracleSanity = useOracleSanityCheck(stxPrice, 'token-stx');
 
   const [activeLoan, setActiveLoan] = useState<UserLoan | null>(null);
   const [repaymentAmount, setRepaymentAmount] = useState<RepaymentAmount | null>(null);
@@ -21,6 +25,18 @@ export const RepayCard: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState('');
   const [timeElapsed, setTimeElapsed] = useState('');
   const [lastTxId, setLastTxId] = useState<string | null>(null);
+  const oracleWarningBanner = oracleSanity.warning ? (
+    <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-lg" role="alert">
+      <AlertCircle className="text-amber-600 flex-shrink-0 mt-0.5" size={20} />
+      <div className="flex-1">
+        <h4 className="text-sm font-semibold text-amber-900 mb-1">Oracle Price Sanity Warning</h4>
+        <p className="text-xs text-amber-800">
+          The oracle price differs from Bitflow&apos;s live STX/USDA quote by{' '}
+          {(oracleSanity.deviation * 100).toFixed(1)}%. Review the market price before repaying.
+        </p>
+      </div>
+    </div>
+  ) : null;
 
   // Fetch active loan and repayment amount on a 60s smart interval
   const fetchData = useCallback(async () => {
@@ -125,6 +141,8 @@ export const RepayCard: React.FC = () => {
           </div>
         </div>
 
+        {oracleWarningBanner}
+
         <div className="bg-gray-50/80 rounded-xl p-6 text-center border border-gray-100">
           <AlertCircle className="mx-auto text-gray-400 mb-3" size={48} aria-hidden="true" />
           <p className="text-gray-600 mb-1 font-medium">No Active Loan</p>
@@ -151,6 +169,8 @@ export const RepayCard: React.FC = () => {
           <p className="text-sm text-gray-500">Pay back your active loan</p>
         </div>
       </div>
+
+      {oracleWarningBanner}
 
       {/* Loan Progress Bar */}
       <div className="space-y-2">

--- a/frontend/src/components/__tests__/BorrowCard.test.tsx
+++ b/frontend/src/components/__tests__/BorrowCard.test.tsx
@@ -7,6 +7,10 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BorrowCard } from '../BorrowCard';
 
+const { mockOracleSanityState } = vi.hoisted(() => ({
+  mockOracleSanityState: { current: { warning: false, deviation: 0 } },
+}));
+
 // Mock hooks
 const mockBorrow = vi.fn();
 const mockGetUserDeposit = vi.fn();
@@ -29,6 +33,18 @@ vi.mock('../../hooks/useVault', () => ({
     getUserLoan: mockGetUserLoan,
     pollTransactionStatus: mockPollTransactionStatus,
   }),
+}));
+
+vi.mock('../../hooks/useStxPrice', () => ({
+  useStxPrice: () => ({
+    price: 1.5,
+    lastUpdated: new Date(),
+    isStale: false,
+  }),
+}));
+
+vi.mock('../../hooks/useOracleSanityCheck', () => ({
+  useOracleSanityCheck: () => mockOracleSanityState.current,
 }));
 
 vi.mock('../../types/vault', () => ({

--- a/frontend/src/components/__tests__/BorrowCard.test.tsx
+++ b/frontend/src/components/__tests__/BorrowCard.test.tsx
@@ -135,6 +135,18 @@ describe('BorrowCard Component', () => {
       render(<BorrowCard />);
       expect(screen.getByText(/150% collateralization required/)).toBeInTheDocument();
     });
+
+    it('shows the oracle sanity warning banner when the price diverges', () => {
+      mockOracleSanityState.current = {
+        warning: true,
+        deviation: 0.08,
+      };
+
+      render(<BorrowCard />);
+
+      expect(screen.getByText('Oracle Price Sanity Warning')).toBeInTheDocument();
+      expect(screen.getByText(/8.0%/)).toBeInTheDocument();
+    });
   });
 
   describe('Active Loan State', () => {

--- a/frontend/src/components/__tests__/HealthMonitor.test.tsx
+++ b/frontend/src/components/__tests__/HealthMonitor.test.tsx
@@ -6,6 +6,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { HealthMonitor } from '../HealthMonitor';
 
+const { mockOracleSanityState } = vi.hoisted(() => ({
+  mockOracleSanityState: { current: { warning: false, deviation: 0 } },
+}));
+
 // Mock useAuth
 vi.mock('../../hooks/useAuth', () => ({
   useAuth: () => ({
@@ -33,6 +37,10 @@ vi.mock('../../hooks/useStxPrice', () => ({
     lastUpdated: new Date(),
     isStale: false,
   }),
+}));
+
+vi.mock('../../hooks/useOracleSanityCheck', () => ({
+  useOracleSanityCheck: () => mockOracleSanityState.current,
 }));
 
 vi.mock('../../utils/formatters', () => ({

--- a/frontend/src/components/__tests__/HealthMonitor.test.tsx
+++ b/frontend/src/components/__tests__/HealthMonitor.test.tsx
@@ -99,4 +99,16 @@ describe('HealthMonitor Component', () => {
     render(<HealthMonitor />);
     expect(screen.getAllByTestId('check-icon').length).toBeGreaterThan(0);
   });
+
+  it('shows the oracle sanity warning banner when the price diverges', () => {
+    mockOracleSanityState.current = {
+      warning: true,
+      deviation: 0.12,
+    };
+
+    render(<HealthMonitor />);
+
+    expect(screen.getByText('Oracle Price Sanity Warning')).toBeInTheDocument();
+    expect(screen.getByText(/12.0%/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/RepayCard.test.tsx
+++ b/frontend/src/components/__tests__/RepayCard.test.tsx
@@ -7,6 +7,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RepayCard } from '../RepayCard';
 
+const { mockOracleSanityState } = vi.hoisted(() => ({
+  mockOracleSanityState: { current: { warning: false, deviation: 0 } },
+}));
+
 // Mock hooks
 const mockRepay = vi.fn();
 const mockGetUserLoan = vi.fn();
@@ -28,6 +32,18 @@ vi.mock('../../hooks/useVault', () => ({
     getRepaymentAmount: mockGetRepaymentAmount,
     pollTransactionStatus: mockPollTransactionStatus,
   }),
+}));
+
+vi.mock('../../hooks/useStxPrice', () => ({
+  useStxPrice: () => ({
+    price: 1.5,
+    lastUpdated: new Date(),
+    isStale: false,
+  }),
+}));
+
+vi.mock('../../hooks/useOracleSanityCheck', () => ({
+  useOracleSanityCheck: () => mockOracleSanityState.current,
 }));
 
 vi.mock('../../types/vault', () => ({

--- a/frontend/src/components/__tests__/RepayCard.test.tsx
+++ b/frontend/src/components/__tests__/RepayCard.test.tsx
@@ -86,6 +86,18 @@ describe('RepayCard Component', () => {
       render(<RepayCard />);
       expect(screen.getByText('Repay Loan')).toBeInTheDocument();
     });
+
+    it('shows the oracle sanity warning banner when the price diverges', () => {
+      mockOracleSanityState.current = {
+        warning: true,
+        deviation: 0.1,
+      };
+
+      render(<RepayCard />);
+
+      expect(screen.getByText('Oracle Price Sanity Warning')).toBeInTheDocument();
+      expect(screen.getByText(/10.0%/)).toBeInTheDocument();
+    });
   });
 
   describe('Active Loan Display', () => {

--- a/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
+++ b/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { useOracleSanityCheck } from '../useOracleSanityCheck';
+
+const mockGetQuoteForRoute = vi.hoisted(() => vi.fn());
+
+vi.mock('@bitflowlabs/core-sdk', () => ({
+  BitflowSDK: class {
+    getQuoteForRoute = mockGetQuoteForRoute;
+  },
+}));
+
+type QuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
+
+describe('useOracleSanityCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a warning when the oracle diverges by more than 5 percent', async () => {
+    const quote: QuoteResult = {
+      bestRoute: {
+        route: {
+          dex_path: ['alex'],
+          token_path: ['token-stx', 'token-usda'],
+          postConditions: {},
+          quoteData: {
+            contract: 'SP000.mock-router',
+            function: 'quote',
+            parameters: {},
+          },
+          swapData: {
+            contract: 'SP000.mock-router',
+            function: 'swap',
+            parameters: {},
+          },
+          tokenXDecimals: 6,
+          tokenYDecimals: 6,
+        },
+        quote: 1.25,
+        params: {},
+        quoteData: {
+          contract: 'SP000.mock-router',
+          function: 'quote',
+          parameters: {},
+        },
+        swapData: {
+          contract: 'SP000.mock-router',
+          function: 'swap',
+          parameters: {},
+        },
+        dexPath: ['alex'],
+        tokenPath: ['token-stx', 'token-usda'],
+        tokenXDecimals: 6,
+        tokenYDecimals: 6,
+      },
+      allRoutes: [],
+      inputData: {
+        tokenX: 'token-stx',
+        tokenY: 'token-usda',
+        amountInput: 1,
+      },
+    };
+
+    mockGetQuoteForRoute.mockResolvedValue(quote);
+
+    const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
+
+    await waitFor(() => {
+      expect(result.current.warning).toBe(true);
+      expect(result.current.deviation).toBeCloseTo(0.25, 2);
+    });
+
+    expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 1);
+  });
+
+  it('does not warn when the market quote stays within the threshold', async () => {
+    const quote: QuoteResult = {
+      bestRoute: {
+        route: {
+          dex_path: ['alex'],
+          token_path: ['token-stx', 'token-usda'],
+          postConditions: {},
+          quoteData: {
+            contract: 'SP000.mock-router',
+            function: 'quote',
+            parameters: {},
+          },
+          swapData: {
+            contract: 'SP000.mock-router',
+            function: 'swap',
+            parameters: {},
+          },
+          tokenXDecimals: 6,
+          tokenYDecimals: 6,
+        },
+        quote: 1.03,
+        params: {},
+        quoteData: {
+          contract: 'SP000.mock-router',
+          function: 'quote',
+          parameters: {},
+        },
+        swapData: {
+          contract: 'SP000.mock-router',
+          function: 'swap',
+          parameters: {},
+        },
+        dexPath: ['alex'],
+        tokenPath: ['token-stx', 'token-usda'],
+        tokenXDecimals: 6,
+        tokenYDecimals: 6,
+      },
+      allRoutes: [],
+      inputData: {
+        tokenX: 'token-stx',
+        tokenY: 'token-usda',
+        amountInput: 1,
+      },
+    };
+
+    mockGetQuoteForRoute.mockResolvedValue(quote);
+
+    const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
+
+    await waitFor(() => {
+      expect(result.current.warning).toBe(false);
+      expect(result.current.deviation).toBeCloseTo(0.03, 2);
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
+++ b/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
 import type { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { useOracleSanityCheck } from '../useOracleSanityCheck';
 
@@ -17,6 +17,16 @@ describe('useOracleSanityCheck', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const flushPromises = async () => {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
 
   it('returns a warning when the oracle diverges by more than 5 percent', async () => {
     const quote: QuoteResult = {
@@ -67,10 +77,10 @@ describe('useOracleSanityCheck', () => {
 
     const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
 
-    await waitFor(() => {
-      expect(result.current.warning).toBe(true);
-      expect(result.current.deviation).toBeCloseTo(0.25, 2);
-    });
+    await flushPromises();
+
+    expect(result.current.warning).toBe(true);
+    expect(result.current.deviation).toBeCloseTo(0.25, 2);
 
     expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 1);
   });
@@ -124,10 +134,10 @@ describe('useOracleSanityCheck', () => {
 
     const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
 
-    await waitFor(() => {
-      expect(result.current.warning).toBe(false);
-      expect(result.current.deviation).toBeCloseTo(0.03, 2);
-    });
+    await flushPromises();
+
+    expect(result.current.warning).toBe(false);
+    expect(result.current.deviation).toBeCloseTo(0.03, 2);
   });
 
   it('refreshes the Bitflow quote on the polling interval', async () => {
@@ -181,29 +191,27 @@ describe('useOracleSanityCheck', () => {
 
     const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
 
-    await waitFor(() => {
-      expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(1);
-      expect(result.current.warning).toBe(false);
-    });
+    await flushPromises();
+
+    expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(1);
+    expect(result.current.warning).toBe(false);
 
     act(() => {
       vi.advanceTimersByTime(30_000);
     });
 
-    await waitFor(() => {
-      expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(2);
-    });
+    await flushPromises();
 
-    vi.useRealTimers();
+    expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(2);
   });
 
   it('fails closed when the oracle price is invalid', async () => {
     const { result } = renderHook(() => useOracleSanityCheck(0, 'token-stx'));
 
-    await waitFor(() => {
-      expect(result.current.warning).toBe(false);
-      expect(result.current.deviation).toBe(0);
-    });
+    await flushPromises();
+
+    expect(result.current.warning).toBe(false);
+    expect(result.current.deviation).toBe(0);
 
     expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
   });
@@ -213,9 +221,9 @@ describe('useOracleSanityCheck', () => {
 
     const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
 
-    await waitFor(() => {
-      expect(result.current.warning).toBe(false);
-      expect(result.current.deviation).toBe(0);
-    });
+    await flushPromises();
+
+    expect(result.current.warning).toBe(false);
+    expect(result.current.deviation).toBe(0);
   });
 });

--- a/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
+++ b/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { useOracleSanityCheck } from '../useOracleSanityCheck';
 
@@ -128,5 +128,72 @@ describe('useOracleSanityCheck', () => {
       expect(result.current.warning).toBe(false);
       expect(result.current.deviation).toBeCloseTo(0.03, 2);
     });
+  });
+
+  it('refreshes the Bitflow quote on the polling interval', async () => {
+    vi.useFakeTimers();
+
+    const quote: QuoteResult = {
+      bestRoute: {
+        route: {
+          dex_path: ['alex'],
+          token_path: ['token-stx', 'token-usda'],
+          postConditions: {},
+          quoteData: {
+            contract: 'SP000.mock-router',
+            function: 'quote',
+            parameters: {},
+          },
+          swapData: {
+            contract: 'SP000.mock-router',
+            function: 'swap',
+            parameters: {},
+          },
+          tokenXDecimals: 6,
+          tokenYDecimals: 6,
+        },
+        quote: 1.0,
+        params: {},
+        quoteData: {
+          contract: 'SP000.mock-router',
+          function: 'quote',
+          parameters: {},
+        },
+        swapData: {
+          contract: 'SP000.mock-router',
+          function: 'swap',
+          parameters: {},
+        },
+        dexPath: ['alex'],
+        tokenPath: ['token-stx', 'token-usda'],
+        tokenXDecimals: 6,
+        tokenYDecimals: 6,
+      },
+      allRoutes: [],
+      inputData: {
+        tokenX: 'token-stx',
+        tokenY: 'token-usda',
+        amountInput: 1,
+      },
+    };
+
+    mockGetQuoteForRoute.mockResolvedValue(quote);
+
+    const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
+
+    await waitFor(() => {
+      expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(1);
+      expect(result.current.warning).toBe(false);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    await waitFor(() => {
+      expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(2);
+    });
+
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
+++ b/frontend/src/hooks/__tests__/useOracleSanityCheck.test.ts
@@ -196,4 +196,26 @@ describe('useOracleSanityCheck', () => {
 
     vi.useRealTimers();
   });
+
+  it('fails closed when the oracle price is invalid', async () => {
+    const { result } = renderHook(() => useOracleSanityCheck(0, 'token-stx'));
+
+    await waitFor(() => {
+      expect(result.current.warning).toBe(false);
+      expect(result.current.deviation).toBe(0);
+    });
+
+    expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the Bitflow quote request rejects', async () => {
+    mockGetQuoteForRoute.mockRejectedValue(new Error('Bitflow unavailable'));
+
+    const { result } = renderHook(() => useOracleSanityCheck(1.0, 'token-stx'));
+
+    await waitFor(() => {
+      expect(result.current.warning).toBe(false);
+      expect(result.current.deviation).toBe(0);
+    });
+  });
 });

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -2,5 +2,6 @@ export { useAuth } from './useAuth';
 export { useVault } from './useVault';
 export { useSmartPolling } from './useSmartPolling';
 export { useStxPrice } from './useStxPrice';
+export { useOracleSanityCheck } from './useOracleSanityCheck';
 export { useToast } from './useToast';
 export { useProtocolStats } from './useProtocolStats';

--- a/frontend/src/hooks/useOracleSanityCheck.ts
+++ b/frontend/src/hooks/useOracleSanityCheck.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { BitflowSDK } from '@bitflowlabs/core-sdk';
 
 export interface OracleSanityCheckResult {
   warning: boolean;
@@ -11,17 +12,57 @@ const DEFAULT_RESULT: OracleSanityCheckResult = {
 };
 
 export const ORACLE_SANITY_THRESHOLD = 0.05;
+const ORACLE_SANITY_INTERVAL_MS = 30_000;
+const ORACLE_TOKEN_IN = 'token-stx';
+const ORACLE_TOKEN_OUT = 'token-usda';
+
+const bitflow = new BitflowSDK();
 
 /**
  * Compares the current oracle price to the Bitflow market quote.
  * The fetch logic is added in a later commit so the hook API can be adopted safely.
  */
 export function useOracleSanityCheck(_oraclePrice: number, tokenId: string): OracleSanityCheckResult {
-  const [state] = useState<OracleSanityCheckResult>(DEFAULT_RESULT);
+  const [state, setState] = useState<OracleSanityCheckResult>(DEFAULT_RESULT);
 
-  if (!tokenId.trim()) {
-    return DEFAULT_RESULT;
-  }
+  useEffect(() => {
+    let cancelled = false;
+
+    const refreshQuote = async () => {
+      try {
+        if (!tokenId.trim() || !Number.isFinite(_oraclePrice) || _oraclePrice <= 0) {
+          if (!cancelled) {
+            setState(DEFAULT_RESULT);
+          }
+          return;
+        }
+
+        const quote = await bitflow.getQuoteForRoute(ORACLE_TOKEN_IN, ORACLE_TOKEN_OUT, 1);
+        const marketRate = Number(quote?.bestRoute?.quote ?? 0);
+        const deviation = Math.abs(_oraclePrice - marketRate) / _oraclePrice;
+
+        if (!cancelled) {
+          setState({
+            warning: false,
+            deviation,
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setState(DEFAULT_RESULT);
+        }
+      }
+    };
+
+    refreshQuote();
+
+    const intervalId = setInterval(refreshQuote, ORACLE_SANITY_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [_oraclePrice, tokenId]);
 
   return state;
 }

--- a/frontend/src/hooks/useOracleSanityCheck.ts
+++ b/frontend/src/hooks/useOracleSanityCheck.ts
@@ -22,7 +22,7 @@ const bitflow = new BitflowSDK();
  * Compares the current oracle price to the Bitflow market quote.
  * The fetch logic is added in a later commit so the hook API can be adopted safely.
  */
-export function useOracleSanityCheck(_oraclePrice: number, tokenId: string): OracleSanityCheckResult {
+export function useOracleSanityCheck(oraclePrice: number, tokenId: string): OracleSanityCheckResult {
   const [state, setState] = useState<OracleSanityCheckResult>(DEFAULT_RESULT);
 
   useEffect(() => {
@@ -30,7 +30,7 @@ export function useOracleSanityCheck(_oraclePrice: number, tokenId: string): Ora
 
     const refreshQuote = async () => {
       try {
-        if (!tokenId.trim() || !Number.isFinite(_oraclePrice) || _oraclePrice <= 0) {
+        if (!tokenId.trim() || !Number.isFinite(oraclePrice) || oraclePrice <= 0) {
           if (!cancelled) {
             setState(DEFAULT_RESULT);
           }
@@ -39,11 +39,19 @@ export function useOracleSanityCheck(_oraclePrice: number, tokenId: string): Ora
 
         const quote = await bitflow.getQuoteForRoute(ORACLE_TOKEN_IN, ORACLE_TOKEN_OUT, 1);
         const marketRate = Number(quote?.bestRoute?.quote ?? 0);
-        const deviation = Math.abs(_oraclePrice - marketRate) / _oraclePrice;
+
+        if (!Number.isFinite(marketRate) || marketRate <= 0) {
+          if (!cancelled) {
+            setState(DEFAULT_RESULT);
+          }
+          return;
+        }
+
+        const deviation = Math.abs(oraclePrice - marketRate) / oraclePrice;
 
         if (!cancelled) {
           setState({
-            warning: false,
+            warning: deviation > ORACLE_SANITY_THRESHOLD,
             deviation,
           });
         }
@@ -62,7 +70,7 @@ export function useOracleSanityCheck(_oraclePrice: number, tokenId: string): Ora
       cancelled = true;
       clearInterval(intervalId);
     };
-  }, [_oraclePrice, tokenId]);
+  }, [oraclePrice, tokenId]);
 
   return state;
 }

--- a/frontend/src/hooks/useOracleSanityCheck.ts
+++ b/frontend/src/hooks/useOracleSanityCheck.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export interface OracleSanityCheckResult {
+  warning: boolean;
+  deviation: number;
+}
+
+const DEFAULT_RESULT: OracleSanityCheckResult = {
+  warning: false,
+  deviation: 0,
+};
+
+export const ORACLE_SANITY_THRESHOLD = 0.05;
+
+/**
+ * Compares the current oracle price to the Bitflow market quote.
+ * The fetch logic is added in a later commit so the hook API can be adopted safely.
+ */
+export function useOracleSanityCheck(_oraclePrice: number, tokenId: string): OracleSanityCheckResult {
+  const [state] = useState<OracleSanityCheckResult>(DEFAULT_RESULT);
+
+  if (!tokenId.trim()) {
+    return DEFAULT_RESULT;
+  }
+
+  return state;
+}
+
+export default useOracleSanityCheck;

--- a/frontend/src/hooks/useOracleSanityCheck.ts
+++ b/frontend/src/hooks/useOracleSanityCheck.ts
@@ -28,15 +28,17 @@ export function useOracleSanityCheck(oraclePrice: number, tokenId: string): Orac
   useEffect(() => {
     let cancelled = false;
 
+    const isInputValid = tokenId.trim().length > 0 && Number.isFinite(oraclePrice) && oraclePrice > 0;
+
+    if (!isInputValid) {
+      setState(DEFAULT_RESULT);
+      return () => {
+        cancelled = true;
+      };
+    }
+
     const refreshQuote = async () => {
       try {
-        if (!tokenId.trim() || !Number.isFinite(oraclePrice) || oraclePrice <= 0) {
-          if (!cancelled) {
-            setState(DEFAULT_RESULT);
-          }
-          return;
-        }
-
         const quote = await bitflow.getQuoteForRoute(ORACLE_TOKEN_IN, ORACLE_TOKEN_OUT, 1);
         const marketRate = Number(quote?.bestRoute?.quote ?? 0);
 


### PR DESCRIPTION
## Summary
- add a reusable  hook that polls Bitflow live STX/USDA quotes every 30 seconds
- warn in borrow, repay, and health monitor flows when the oracle price deviates by more than 5%
- add hook, component, and integration coverage plus a short frontend README note

