### PR TITLE
Fix/oracle sanity check

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,6 +23,7 @@ Modern, responsive dashboard for depositing STX, borrowing against collateral, a
 
 ```bash
 # Install dependencies
+The deposit flow now includes a live Bitflow collateral preview so users can see the USDA value and route estimate before submitting STX.
 npm install
 
 # Copy environment configuration
@@ -37,6 +38,7 @@ npm run dev
 
 The app will be available at `http://localhost:5173`
 
+│   │   ├── CollateralPreview.tsx # Live Bitflow collateral preview
 ## Environment Variables
 
 All environment variables must be prefixed with `VITE_` to be accessible in the browser.
@@ -69,11 +71,7 @@ All environment variables must be prefixed with `VITE_` to be accessible in the 
 
 Never commit `.env` files with real values to version control.
 
-## Available Scripts
-
-### Development
-
-```bash
+- **Collateral Preview:** Live Bitflow STX to USDA estimate appears while entering deposit amounts
 npm run dev          # Start dev server with hot reload
 npm run build        # Production build (TypeScript + Vite)
 npm run preview      # Preview production build locally

--- a/frontend/src/components/CollateralPreview.tsx
+++ b/frontend/src/components/CollateralPreview.tsx
@@ -58,8 +58,12 @@ export const CollateralPreview: React.FC<CollateralPreviewProps> = ({ stxAmount,
         const bestRoute = quoteResult.bestRoute as PreviewRoute | null;
         const estimatedOutput = extractEstimatedOutput(bestRoute);
 
-        if (!bestRoute || estimatedOutput === null) {
-          throw new Error('Bitflow did not return a live route for this amount.');
+        if (!bestRoute || quoteResult.allRoutes.length === 0) {
+          throw new Error('No live Bitflow route is available for this amount right now.');
+        }
+
+        if (estimatedOutput === null) {
+          throw new Error('Bitflow returned a route without an output amount.');
         }
 
         if (!active) {

--- a/frontend/src/components/CollateralPreview.tsx
+++ b/frontend/src/components/CollateralPreview.tsx
@@ -1,0 +1,350 @@
+import React, { useEffect, useState } from 'react';
+import { ArrowRight, AlertTriangle, Coins, RefreshCw } from 'lucide-react';
+import { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { formatPercentage, formatSTX, formatUSD } from '../utils/formatters';
+
+type BitflowQuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
+
+type PreviewRoute = NonNullable<BitflowQuoteResult['bestRoute']> & {
+  tokenYAmount?: number | null;
+  priceImpact?: number | null;
+  priceImpactPercent?: number | null;
+  price_impact?: number | null;
+  impact?: number | null;
+};
+
+type PreviewQuoteResult = Omit<BitflowQuoteResult, 'bestRoute'> & {
+  bestRoute: PreviewRoute | null;
+};
+
+interface CollateralPreviewProps {
+  stxAmount: number;
+  className?: string;
+}
+
+type PreviewStatus = 'idle' | 'loading' | 'success' | 'error';
+
+const bitflow = new BitflowSDK();
+const DEBOUNCE_MS = 500;
+const INPUT_TOKEN = 'token-stx';
+const OUTPUT_TOKEN = 'token-usda';
+
+const TOKEN_LABELS: Record<string, string> = {
+  'token-stx': 'STX',
+  'token-usda': 'USDA',
+};
+
+const normalizeAmount = (value: number): number | null => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  return value;
+};
+
+const formatTokenLabel = (token: string): string => {
+  return TOKEN_LABELS[token] ?? token.replace(/[-_]/g, ' ').toUpperCase();
+};
+
+const formatDexLabel = (dex: string): string => {
+  return dex.replace(/[-_]/g, ' ').toUpperCase();
+};
+
+const extractEstimatedOutput = (bestRoute: PreviewRoute | null): number | null => {
+  if (!bestRoute) {
+    return null;
+  }
+
+  const candidate = bestRoute.tokenYAmount ?? bestRoute.quote;
+
+  return typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0
+    ? candidate
+    : null;
+};
+
+const readNumericValue = (...values: Array<unknown>): number | null => {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+};
+
+const extractPriceImpact = (bestRoute: PreviewRoute | null): number | null => {
+  if (!bestRoute) {
+    return null;
+  }
+
+  const params = bestRoute.params as
+    | { priceImpact?: unknown; price_impact?: unknown; 'price-impact'?: unknown }
+    | undefined;
+  const quoteParams = bestRoute.quoteData?.parameters as
+    | { priceImpact?: unknown; price_impact?: unknown; 'price-impact'?: unknown }
+    | undefined;
+
+  const rawValue = readNumericValue(
+    bestRoute.priceImpact,
+    bestRoute.priceImpactPercent,
+    bestRoute.price_impact,
+    bestRoute.impact,
+    params?.priceImpact,
+    params?.price_impact,
+    params?.['price-impact'],
+    quoteParams?.priceImpact,
+    quoteParams?.price_impact,
+    quoteParams?.['price-impact']
+  );
+
+  if (rawValue === null) {
+    return null;
+  }
+
+  if (Math.abs(rawValue) <= 1) {
+    return rawValue * 100;
+  }
+
+  return rawValue;
+};
+
+const formatPriceImpact = (priceImpact: number): string => {
+  return formatPercentage(Math.abs(priceImpact), 2);
+};
+
+const getRouteLabel = (bestRoute: PreviewRoute | null): string => {
+  if (!bestRoute) {
+    return 'Live Bitflow route';
+  }
+
+  const tokenPath = bestRoute.tokenPath.length > 0
+    ? bestRoute.tokenPath.map(formatTokenLabel).join(' → ')
+    : 'STX → USDA';
+  const dexPath = bestRoute.dexPath.length > 0
+    ? bestRoute.dexPath.map(formatDexLabel).join(' / ')
+    : 'Bitflow';
+
+  return `${tokenPath} via ${dexPath}`;
+};
+
+/**
+ * CollateralPreview Component
+ * Shows a live Bitflow quote for the collateral amount the user is entering.
+ */
+export const CollateralPreview: React.FC<CollateralPreviewProps> = ({ stxAmount, className = '' }) => {
+  const [status, setStatus] = useState<PreviewStatus>('idle');
+  const [quote, setQuote] = useState<PreviewQuoteResult | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [refreshSeed, setRefreshSeed] = useState(0);
+
+  useEffect(() => {
+    const normalizedAmount = normalizeAmount(stxAmount);
+
+    if (normalizedAmount === null) {
+      setStatus('idle');
+      setQuote(null);
+      setErrorMessage(null);
+      return undefined;
+    }
+
+    let active = true;
+    setStatus('loading');
+    setErrorMessage(null);
+
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        const quoteResult = await bitflow.getQuoteForRoute(INPUT_TOKEN, OUTPUT_TOKEN, normalizedAmount);
+        const bestRoute = quoteResult.bestRoute as PreviewRoute | null;
+        const estimatedOutput = extractEstimatedOutput(bestRoute);
+
+        if (!bestRoute || estimatedOutput === null) {
+          throw new Error('Bitflow did not return a live route for this amount.');
+        }
+
+        if (!active) {
+          return;
+        }
+
+        setQuote(quoteResult as PreviewQuoteResult);
+        setStatus('success');
+      } catch (error: unknown) {
+        if (!active) {
+          return;
+        }
+
+        setQuote(null);
+        setStatus('error');
+        setErrorMessage(error instanceof Error && error.message ? error.message : 'Unable to load the live Bitflow preview right now.');
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      active = false;
+      window.clearTimeout(timeoutId);
+    };
+  }, [stxAmount, refreshSeed]);
+
+  const normalizedAmount = normalizeAmount(stxAmount);
+  const bestRoute = quote?.bestRoute ?? null;
+  const estimatedOutput = extractEstimatedOutput(bestRoute);
+  const priceImpact = extractPriceImpact(bestRoute);
+  const routeLabel = getRouteLabel(bestRoute);
+
+  if (normalizedAmount === null) {
+    return (
+      <div
+        className={`rounded-2xl border border-dashed border-[#43515f] bg-[#1F2A37] px-4 py-4 text-slate-200 shadow-sm ${className}`}
+        aria-live="polite"
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#F15A22]/15 ring-1 ring-[#F15A22]/30">
+            <Coins size={18} className="text-[#F15A22]" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Collateral preview</p>
+            <p className="text-sm text-slate-200">Enter an STX amount to preview its USDA value.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <div
+        className={`rounded-2xl border border-slate-700 bg-gradient-to-br from-[#1F2A37] via-[#223140] to-[#111827] px-4 py-4 text-white shadow-lg shadow-slate-950/20 ${className}`}
+        role="status"
+        aria-live="polite"
+        aria-label="Loading collateral preview"
+      >
+        <span className="sr-only">Loading Bitflow collateral preview</span>
+        <div className="animate-pulse space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-xl bg-white/10" />
+            <div className="space-y-2">
+              <div className="h-3 w-32 rounded-full bg-white/10" />
+              <div className="h-4 w-48 rounded-full bg-white/10" />
+            </div>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-3">
+            <div className="h-3 w-28 rounded-full bg-white/10" />
+            <div className="h-8 w-40 rounded-full bg-white/10" />
+            <div className="h-3 w-full rounded-full bg-white/10" />
+            <div className="h-3 w-5/6 rounded-full bg-white/10" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div
+        className={`rounded-2xl border border-[#4b2b21] bg-gradient-to-br from-[#1F2A37] via-[#2b2020] to-[#171c23] px-4 py-4 text-slate-100 shadow-lg shadow-slate-950/20 ${className}`}
+        role="alert"
+        aria-live="assertive"
+      >
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#F15A22]/15 ring-1 ring-[#F15A22]/30">
+            <AlertTriangle size={18} className="text-[#F15A22]" aria-hidden="true" />
+          </div>
+          <div className="flex-1 space-y-2">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Preview unavailable</p>
+              <p className="mt-1 text-sm font-medium text-white">We could not load the live Bitflow route.</p>
+            </div>
+            <p className="text-sm text-slate-300">{errorMessage}</p>
+            <button
+              type="button"
+              onClick={() => setRefreshSeed((value) => value + 1)}
+              className="inline-flex items-center gap-2 rounded-xl border border-[#F15A22]/30 bg-[#F15A22]/10 px-3 py-2 text-sm font-semibold text-[#F15A22] transition-colors hover:bg-[#F15A22]/20"
+            >
+              <RefreshCw size={14} aria-hidden="true" />
+              Try again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'success' && estimatedOutput !== null) {
+    const outputDecimals = estimatedOutput < 1 ? 4 : 2;
+
+    return (
+      <div
+        className={`rounded-2xl border border-slate-700 bg-gradient-to-br from-[#1F2A37] via-[#223140] to-[#111827] px-4 py-4 text-slate-100 shadow-lg shadow-slate-950/20 ${className}`}
+        aria-live="polite"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#F15A22]/15 ring-1 ring-[#F15A22]/30">
+              <Coins size={18} className="text-[#F15A22]" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Collateral preview</p>
+              <p className="text-sm text-slate-200">Live route for {formatSTX(normalizedAmount)} STX</p>
+            </div>
+          </div>
+
+          <div className="rounded-full border border-[#F15A22]/25 bg-[#F15A22]/10 px-3 py-1 text-xs font-semibold text-[#F15A22]">
+            Bitflow live
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Estimated USDA</p>
+              <p className="mt-1 text-3xl font-semibold tracking-tight text-white">{formatUSD(estimatedOutput, outputDecimals)}</p>
+            </div>
+            <p className="text-sm text-slate-300">Worth approximately the same as the collateral route below.</p>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-slate-100">
+            <span className="rounded-full bg-slate-950/30 px-3 py-1 font-medium text-slate-100 ring-1 ring-white/10">
+              {routeLabel}
+            </span>
+            {priceImpact !== null && (
+              <span className="rounded-full border border-[#F15A22]/25 bg-[#F15A22]/10 px-3 py-1 font-medium text-[#F15A22]">
+                Price impact {formatPriceImpact(priceImpact)}
+              </span>
+            )}
+          </div>
+
+          <div className="mt-4 flex items-center gap-2 text-sm text-slate-300">
+            <ArrowRight size={14} className="text-[#F15A22]" aria-hidden="true" />
+            <span>Preview updates after you pause typing for half a second.</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`rounded-2xl border border-dashed border-[#43515f] bg-[#1F2A37] px-4 py-4 text-slate-200 shadow-sm ${className}`}
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#F15A22]/15 ring-1 ring-[#F15A22]/30">
+          <Coins size={18} className="text-[#F15A22]" aria-hidden="true" />
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Collateral preview</p>
+          <p className="text-sm text-slate-200">Waiting for a live Bitflow quote.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CollateralPreview;

--- a/frontend/src/components/CollateralPreview.tsx
+++ b/frontend/src/components/CollateralPreview.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { ArrowRight, AlertTriangle, Coins, RefreshCw } from 'lucide-react';
-import { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { formatSTX, formatUSD } from '../utils/formatters';
 import {
   extractEstimatedOutput,

--- a/frontend/src/components/CollateralPreview.tsx
+++ b/frontend/src/components/CollateralPreview.tsx
@@ -1,17 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { ArrowRight, AlertTriangle, Coins, RefreshCw } from 'lucide-react';
 import { BitflowSDK } from '@bitflowlabs/core-sdk';
-import { formatPercentage, formatSTX, formatUSD } from '../utils/formatters';
-
-type BitflowQuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
-
-type PreviewRoute = NonNullable<BitflowQuoteResult['bestRoute']> & {
-  tokenYAmount?: number | null;
-  priceImpact?: number | null;
-  priceImpactPercent?: number | null;
-  price_impact?: number | null;
-  impact?: number | null;
-};
+import { formatSTX, formatUSD } from '../utils/formatters';
+import {
+  extractEstimatedOutput,
+  extractPriceImpact,
+  formatPriceImpact,
+  getRouteLabel,
+  normalizeAmount,
+  type BitflowQuoteResult,
+  type PreviewRoute,
+} from './collateralPreviewUtils';
 
 type PreviewQuoteResult = Omit<BitflowQuoteResult, 'bestRoute'> & {
   bestRoute: PreviewRoute | null;
@@ -28,112 +27,6 @@ const bitflow = new BitflowSDK();
 const DEBOUNCE_MS = 500;
 const INPUT_TOKEN = 'token-stx';
 const OUTPUT_TOKEN = 'token-usda';
-
-const TOKEN_LABELS: Record<string, string> = {
-  'token-stx': 'STX',
-  'token-usda': 'USDA',
-};
-
-const normalizeAmount = (value: number): number | null => {
-  if (!Number.isFinite(value) || value <= 0) {
-    return null;
-  }
-
-  return value;
-};
-
-const formatTokenLabel = (token: string): string => {
-  return TOKEN_LABELS[token] ?? token.replace(/[-_]/g, ' ').toUpperCase();
-};
-
-const formatDexLabel = (dex: string): string => {
-  return dex.replace(/[-_]/g, ' ').toUpperCase();
-};
-
-const extractEstimatedOutput = (bestRoute: PreviewRoute | null): number | null => {
-  if (!bestRoute) {
-    return null;
-  }
-
-  const candidate = bestRoute.tokenYAmount ?? bestRoute.quote;
-
-  return typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0
-    ? candidate
-    : null;
-};
-
-const readNumericValue = (...values: Array<unknown>): number | null => {
-  for (const value of values) {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
-    }
-
-    if (typeof value === 'string' && value.trim().length > 0) {
-      const parsed = Number(value);
-
-      if (Number.isFinite(parsed)) {
-        return parsed;
-      }
-    }
-  }
-
-  return null;
-};
-
-const extractPriceImpact = (bestRoute: PreviewRoute | null): number | null => {
-  if (!bestRoute) {
-    return null;
-  }
-
-  const params = bestRoute.params as
-    | { priceImpact?: unknown; price_impact?: unknown; 'price-impact'?: unknown }
-    | undefined;
-  const quoteParams = bestRoute.quoteData?.parameters as
-    | { priceImpact?: unknown; price_impact?: unknown; 'price-impact'?: unknown }
-    | undefined;
-
-  const rawValue = readNumericValue(
-    bestRoute.priceImpact,
-    bestRoute.priceImpactPercent,
-    bestRoute.price_impact,
-    bestRoute.impact,
-    params?.priceImpact,
-    params?.price_impact,
-    params?.['price-impact'],
-    quoteParams?.priceImpact,
-    quoteParams?.price_impact,
-    quoteParams?.['price-impact']
-  );
-
-  if (rawValue === null) {
-    return null;
-  }
-
-  if (Math.abs(rawValue) <= 1) {
-    return rawValue * 100;
-  }
-
-  return rawValue;
-};
-
-const formatPriceImpact = (priceImpact: number): string => {
-  return formatPercentage(Math.abs(priceImpact), 2);
-};
-
-const getRouteLabel = (bestRoute: PreviewRoute | null): string => {
-  if (!bestRoute) {
-    return 'Live Bitflow route';
-  }
-
-  const tokenPath = bestRoute.tokenPath.length > 0
-    ? bestRoute.tokenPath.map(formatTokenLabel).join(' → ')
-    : 'STX → USDA';
-  const dexPath = bestRoute.dexPath.length > 0
-    ? bestRoute.dexPath.map(formatDexLabel).join(' / ')
-    : 'Bitflow';
-
-  return `${tokenPath} via ${dexPath}`;
-};
 
 /**
  * CollateralPreview Component

--- a/frontend/src/components/CollateralPreview.tsx
+++ b/frontend/src/components/CollateralPreview.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ArrowRight, AlertTriangle, Coins, RefreshCw } from 'lucide-react';
+import { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { formatSTX, formatUSD } from '../utils/formatters';
 import {
   extractEstimatedOutput,
@@ -57,7 +58,7 @@ export const CollateralPreview: React.FC<CollateralPreviewProps> = ({ stxAmount,
         const bestRoute = quoteResult.bestRoute as PreviewRoute | null;
         const estimatedOutput = extractEstimatedOutput(bestRoute);
 
-        if (!bestRoute || quoteResult.allRoutes.length === 0) {
+        if (!bestRoute) {
           throw new Error('No live Bitflow route is available for this amount right now.');
         }
 

--- a/frontend/src/components/DepositCard.tsx
+++ b/frontend/src/components/DepositCard.tsx
@@ -5,6 +5,7 @@ import { useVault } from '../hooks/useVault';
 import { useSmartPolling } from '../hooks/useSmartPolling';
 import { formatSTX } from '../utils/formatters';
 import { PROTOCOL_CONSTANTS, getExplorerUrl } from '../config/contracts';
+import { CollateralPreview } from './CollateralPreview';
 
 /**
  * DepositCard Component
@@ -97,6 +98,8 @@ export const DepositCard: React.FC = () => {
     setDepositAmount(maxAmount.toString());
   };
 
+  const collateralPreviewAmount = parseFloat(depositAmount);
+
   return (
     <div className="card-elevated space-y-6">
       {/* Header */}
@@ -151,6 +154,8 @@ export const DepositCard: React.FC = () => {
             </span>
           )}
         </div>
+
+        <CollateralPreview stxAmount={collateralPreviewAmount} />
 
         {/* Inline Validation Warnings */}
         <div id="deposit-validation">

--- a/frontend/src/components/__tests__/CollateralPreview.test.tsx
+++ b/frontend/src/components/__tests__/CollateralPreview.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { CollateralPreview } from '../CollateralPreview';
 
@@ -141,5 +141,38 @@ describe('CollateralPreview', () => {
     await flushPromises();
 
     expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 11);
+  });
+
+  it('shows an error fallback and retries after the user asks again', async () => {
+    vi.useFakeTimers();
+
+    mockGetQuoteForRoute
+      .mockRejectedValueOnce(new Error('Bitflow unavailable'))
+      .mockResolvedValue(createQuote());
+
+    render(<CollateralPreview stxAmount={12.3} />);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushPromises();
+
+    expect(screen.getByText(/Preview unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Bitflow unavailable/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Try again/i }));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('$18.42')).toBeInTheDocument();
+    });
+
+    expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/components/__tests__/CollateralPreview.test.tsx
+++ b/frontend/src/components/__tests__/CollateralPreview.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { CollateralPreview } from '../CollateralPreview';
+
+const mockGetQuoteForRoute = vi.hoisted(() => vi.fn());
+
+vi.mock('@bitflowlabs/core-sdk', () => ({
+  BitflowSDK: class {
+    getQuoteForRoute = mockGetQuoteForRoute;
+  },
+}));
+
+type QuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
+type PreviewRoute = NonNullable<QuoteResult['bestRoute']> & {
+  tokenYAmount?: number | null;
+  priceImpact?: number | null;
+};
+type PreviewQuoteResult = Omit<QuoteResult, 'bestRoute'> & {
+  bestRoute: PreviewRoute | null;
+};
+
+const createQuote = (overrides: Partial<PreviewRoute> = {}): PreviewQuoteResult => ({
+  bestRoute: {
+    route: {
+      dex_path: ['alex'],
+      token_path: ['token-stx', 'token-usda'],
+      postConditions: {},
+      quoteData: {
+        contract: 'SP000.mock-router',
+        function: 'quote',
+        parameters: {},
+      },
+      swapData: {
+        contract: 'SP000.mock-router',
+        function: 'swap',
+        parameters: {},
+      },
+      tokenXDecimals: 6,
+      tokenYDecimals: 6,
+    },
+    quote: 18.42,
+    tokenYAmount: 18.42,
+    params: {},
+    quoteData: {
+      contract: 'SP000.mock-router',
+      function: 'quote',
+      parameters: {},
+    },
+    swapData: {
+      contract: 'SP000.mock-router',
+      function: 'swap',
+      parameters: {},
+    },
+    dexPath: ['alex'],
+    tokenPath: ['token-stx', 'token-usda'],
+    tokenXDecimals: 6,
+    tokenYDecimals: 6,
+    priceImpact: 0.0123,
+    ...overrides,
+  },
+  allRoutes: [],
+  inputData: {
+    tokenX: 'token-stx',
+    tokenY: 'token-usda',
+    amountInput: 12.3,
+  },
+});
+
+const flushPromises = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe('CollateralPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the idle prompt when no collateral amount is available', () => {
+    render(<CollateralPreview stxAmount={0} />);
+
+    expect(screen.getByText(/Enter an STX amount to preview its USDA value/i)).toBeInTheDocument();
+    expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
+  });
+
+  it('renders the live quote preview once the Bitflow response resolves', async () => {
+    vi.useFakeTimers();
+
+    mockGetQuoteForRoute.mockResolvedValue(createQuote());
+
+    render(<CollateralPreview stxAmount={12.3} />);
+
+    expect(screen.getByLabelText(/Loading collateral preview/i)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('$18.42')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/STX → USDA via ALEX/i)).toBeInTheDocument();
+    expect(screen.getByText(/Price impact 1.23%/i)).toBeInTheDocument();
+    expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 12.3);
+  });
+});

--- a/frontend/src/components/__tests__/CollateralPreview.test.tsx
+++ b/frontend/src/components/__tests__/CollateralPreview.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { CollateralPreview } from '../CollateralPreview';
 
@@ -73,6 +73,12 @@ const flushPromises = async () => {
   });
 };
 
+const advanceTimersBy = async (milliseconds: number) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(milliseconds);
+  });
+};
+
 describe('CollateralPreview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -98,15 +104,11 @@ describe('CollateralPreview', () => {
 
     expect(screen.getByLabelText(/Loading collateral preview/i)).toBeInTheDocument();
 
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
+    await advanceTimersBy(500);
 
     await flushPromises();
 
-    await waitFor(() => {
-      expect(screen.getByText('$18.42')).toBeInTheDocument();
-    });
+    expect(screen.getByText('$18.42')).toBeInTheDocument();
 
     expect(screen.getByText(/STX → USDA via ALEX/i)).toBeInTheDocument();
     expect(screen.getByText(/Price impact 1.23%/i)).toBeInTheDocument();
@@ -120,23 +122,17 @@ describe('CollateralPreview', () => {
 
     const { rerender } = render(<CollateralPreview stxAmount={10} />);
 
-    act(() => {
-      vi.advanceTimersByTime(250);
-    });
+    await advanceTimersBy(250);
 
     rerender(<CollateralPreview stxAmount={11} />);
 
-    act(() => {
-      vi.advanceTimersByTime(249);
-    });
+    await advanceTimersBy(249);
 
     await flushPromises();
 
     expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
 
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
+    await advanceTimersBy(1);
 
     await flushPromises();
 
@@ -150,15 +146,11 @@ describe('CollateralPreview', () => {
 
     render(<CollateralPreview stxAmount={12.3} />);
 
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
+    await advanceTimersBy(500);
 
     await flushPromises();
 
-    await waitFor(() => {
-      expect(screen.getByText('$23.45')).toBeInTheDocument();
-    });
+    expect(screen.getByText('$23.45')).toBeInTheDocument();
 
     expect(screen.queryByText('$11.11')).not.toBeInTheDocument();
   });
@@ -172,9 +164,7 @@ describe('CollateralPreview', () => {
 
     render(<CollateralPreview stxAmount={12.3} />);
 
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
+    await advanceTimersBy(500);
 
     await flushPromises();
 
@@ -183,15 +173,11 @@ describe('CollateralPreview', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Try again/i }));
 
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
+    await advanceTimersBy(500);
 
     await flushPromises();
 
-    await waitFor(() => {
-      expect(screen.getByText('$18.42')).toBeInTheDocument();
-    });
+    expect(screen.getByText('$18.42')).toBeInTheDocument();
 
     expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(2);
   });

--- a/frontend/src/components/__tests__/CollateralPreview.test.tsx
+++ b/frontend/src/components/__tests__/CollateralPreview.test.tsx
@@ -112,4 +112,34 @@ describe('CollateralPreview', () => {
     expect(screen.getByText(/Price impact 1.23%/i)).toBeInTheDocument();
     expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 12.3);
   });
+
+  it('debounces rapid collateral changes before calling Bitflow', async () => {
+    vi.useFakeTimers();
+
+    mockGetQuoteForRoute.mockResolvedValue(createQuote());
+
+    const { rerender } = render(<CollateralPreview stxAmount={10} />);
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    rerender(<CollateralPreview stxAmount={11} />);
+
+    act(() => {
+      vi.advanceTimersByTime(249);
+    });
+
+    await flushPromises();
+
+    expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    await flushPromises();
+
+    expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 11);
+  });
 });

--- a/frontend/src/components/__tests__/CollateralPreview.test.tsx
+++ b/frontend/src/components/__tests__/CollateralPreview.test.tsx
@@ -126,7 +126,7 @@ describe('CollateralPreview', () => {
 
     rerender(<CollateralPreview stxAmount={11} />);
 
-    await advanceTimersBy(249);
+    await advanceTimersBy(499);
 
     await flushPromises();
 

--- a/frontend/src/components/__tests__/CollateralPreview.test.tsx
+++ b/frontend/src/components/__tests__/CollateralPreview.test.tsx
@@ -155,6 +155,28 @@ describe('CollateralPreview', () => {
     expect(screen.queryByText('$11.11')).not.toBeInTheDocument();
   });
 
+  it('shows a clear error when Bitflow has no route for the amount', async () => {
+    vi.useFakeTimers();
+
+    mockGetQuoteForRoute.mockResolvedValue({
+      bestRoute: null,
+      allRoutes: [],
+      inputData: {
+        tokenX: 'token-stx',
+        tokenY: 'token-usda',
+        amountInput: 12.3,
+      },
+    });
+
+    render(<CollateralPreview stxAmount={12.3} />);
+
+    await advanceTimersBy(500);
+
+    await flushPromises();
+
+    expect(screen.getByText(/No live Bitflow route is available for this amount right now/i)).toBeInTheDocument();
+  });
+
   it('shows an error fallback and retries after the user asks again', async () => {
     vi.useFakeTimers();
 

--- a/frontend/src/components/__tests__/CollateralPreview.test.tsx
+++ b/frontend/src/components/__tests__/CollateralPreview.test.tsx
@@ -143,6 +143,26 @@ describe('CollateralPreview', () => {
     expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stx', 'token-usda', 11);
   });
 
+  it('uses tokenYAmount from the live route when it is available', async () => {
+    vi.useFakeTimers();
+
+    mockGetQuoteForRoute.mockResolvedValue(createQuote({ quote: 11.11, tokenYAmount: 23.45 }));
+
+    render(<CollateralPreview stxAmount={12.3} />);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('$23.45')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('$11.11')).not.toBeInTheDocument();
+  });
+
   it('shows an error fallback and retries after the user asks again', async () => {
     vi.useFakeTimers();
 

--- a/frontend/src/components/__tests__/DepositCard.test.tsx
+++ b/frontend/src/components/__tests__/DepositCard.test.tsx
@@ -90,6 +90,11 @@ describe('DepositCard Component', () => {
       expect(screen.getByText(/Available:/)).toBeInTheDocument();
     });
 
+    it('renders the collateral preview block', () => {
+      render(<DepositCard />);
+      expect(screen.getByTestId('collateral-preview')).toBeInTheDocument();
+    });
+
     it('shows deposit button', () => {
       render(<DepositCard />);
       const btn = screen.getByRole('button', { name: /Deposit STX/i });
@@ -141,6 +146,16 @@ describe('DepositCard Component', () => {
       await user.type(input, '10');
       
       expect(screen.getByText(/Max borrow after deposit/)).toBeInTheDocument();
+    });
+
+    it('passes the typed collateral amount to the preview', async () => {
+      const user = userEvent.setup();
+      render(<DepositCard />);
+
+      const input = screen.getByPlaceholderText('0.00');
+      await user.type(input, '10');
+
+      expect(screen.getByTestId('collateral-preview')).toHaveTextContent('10');
     });
   });
 

--- a/frontend/src/components/__tests__/DepositCard.test.tsx
+++ b/frontend/src/components/__tests__/DepositCard.test.tsx
@@ -41,6 +41,12 @@ vi.mock('../../config/contracts', () => ({
   getExplorerUrl: (txId: string) => `https://explorer.hiro.so/txid/${txId}`,
 }));
 
+vi.mock('../CollateralPreview', () => ({
+  CollateralPreview: ({ stxAmount }: { stxAmount: number }) => (
+    <div data-testid="collateral-preview">{Number.isFinite(stxAmount) ? stxAmount : 'invalid'}</div>
+  ),
+}));
+
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
   ArrowDownCircle: () => <span>ArrowDownCircle</span>,

--- a/frontend/src/components/__tests__/collateralPreviewUtils.test.ts
+++ b/frontend/src/components/__tests__/collateralPreviewUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractEstimatedOutput,
+  extractPriceImpact,
+  formatPriceImpact,
+  getRouteLabel,
+  normalizeAmount,
+  type PreviewRoute,
+} from '../collateralPreviewUtils';
+
+const createRoute = (overrides: Partial<PreviewRoute> = {}): PreviewRoute => ({
+  route: {
+    dex_path: ['alex'],
+    token_path: ['token-stx', 'token-usda'],
+    postConditions: {},
+    quoteData: {
+      contract: 'SP000.mock-router',
+      function: 'quote',
+      parameters: {},
+    },
+    swapData: {
+      contract: 'SP000.mock-router',
+      function: 'swap',
+      parameters: {},
+    },
+    tokenXDecimals: 6,
+    tokenYDecimals: 6,
+  },
+  quote: 18.42,
+  tokenYAmount: 18.42,
+  params: {},
+  quoteData: {
+    contract: 'SP000.mock-router',
+    function: 'quote',
+    parameters: {},
+  },
+  swapData: {
+    contract: 'SP000.mock-router',
+    function: 'swap',
+    parameters: {},
+  },
+  dexPath: ['alex'],
+  tokenPath: ['token-stx', 'token-usda'],
+  tokenXDecimals: 6,
+  tokenYDecimals: 6,
+  ...overrides,
+});
+
+describe('collateralPreviewUtils', () => {
+  it('normalizes invalid collateral amounts to null', () => {
+    expect(normalizeAmount(0)).toBeNull();
+    expect(normalizeAmount(-1)).toBeNull();
+    expect(normalizeAmount(Number.NaN)).toBeNull();
+  });
+
+  it('keeps positive collateral amounts intact', () => {
+    expect(normalizeAmount(12.5)).toBe(12.5);
+  });
+
+  it('prefers tokenYAmount over the legacy quote value', () => {
+    const route = createRoute({ quote: 11.11, tokenYAmount: 23.45 });
+
+    expect(extractEstimatedOutput(route)).toBe(23.45);
+  });
+
+  it('formats the live route label from the token and dex path', () => {
+    const route = createRoute();
+
+    expect(getRouteLabel(route)).toBe('STX → USDA via ALEX');
+  });
+
+  it('normalizes fractional price impact values into percentages', () => {
+    const route = createRoute({ priceImpact: 0.0123 });
+
+    expect(extractPriceImpact(route)).toBeCloseTo(1.23, 2);
+    expect(formatPriceImpact(1.23)).toBe('1.23%');
+  });
+
+  it('returns null when no route exists', () => {
+    expect(extractEstimatedOutput(null)).toBeNull();
+    expect(extractPriceImpact(null)).toBeNull();
+    expect(getRouteLabel(null)).toBe('Live Bitflow route');
+  });
+});

--- a/frontend/src/components/collateralPreviewUtils.ts
+++ b/frontend/src/components/collateralPreviewUtils.ts
@@ -1,0 +1,119 @@
+import { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { formatPercentage } from '../utils/formatters';
+
+export type BitflowQuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
+
+export type PreviewRoute = NonNullable<BitflowQuoteResult['bestRoute']> & {
+  tokenYAmount?: number | null;
+  priceImpact?: number | null;
+  priceImpactPercent?: number | null;
+  price_impact?: number | null;
+  impact?: number | null;
+  params?: Record<string, unknown>;
+};
+
+export const TOKEN_LABELS: Record<string, string> = {
+  'token-stx': 'STX',
+  'token-usda': 'USDA',
+};
+
+export const normalizeAmount = (value: number): number | null => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  return value;
+};
+
+export const formatTokenLabel = (token: string): string => {
+  return TOKEN_LABELS[token] ?? token.replace(/[-_]/g, ' ').toUpperCase();
+};
+
+export const formatDexLabel = (dex: string): string => {
+  return dex.replace(/[-_]/g, ' ').toUpperCase();
+};
+
+export const extractEstimatedOutput = (bestRoute: PreviewRoute | null): number | null => {
+  if (!bestRoute) {
+    return null;
+  }
+
+  const candidate = bestRoute.tokenYAmount ?? bestRoute.quote;
+
+  return typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0
+    ? candidate
+    : null;
+};
+
+const readNumericValue = (...values: Array<unknown>): number | null => {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const extractPriceImpact = (bestRoute: PreviewRoute | null): number | null => {
+  if (!bestRoute) {
+    return null;
+  }
+
+  const params = bestRoute.params as
+    | { priceImpact?: unknown; price_impact?: unknown; 'price-impact'?: unknown }
+    | undefined;
+  const quoteParams = bestRoute.quoteData?.parameters as
+    | { priceImpact?: unknown; price_impact?: unknown; 'price-impact'?: unknown }
+    | undefined;
+
+  const rawValue = readNumericValue(
+    bestRoute.priceImpact,
+    bestRoute.priceImpactPercent,
+    bestRoute.price_impact,
+    bestRoute.impact,
+    params?.priceImpact,
+    params?.price_impact,
+    params?.['price-impact'],
+    quoteParams?.priceImpact,
+    quoteParams?.price_impact,
+    quoteParams?.['price-impact']
+  );
+
+  if (rawValue === null) {
+    return null;
+  }
+
+  if (Math.abs(rawValue) <= 1) {
+    return rawValue * 100;
+  }
+
+  return rawValue;
+};
+
+export const formatPriceImpact = (priceImpact: number): string => {
+  return formatPercentage(Math.abs(priceImpact), 2);
+};
+
+export const getRouteLabel = (bestRoute: PreviewRoute | null): string => {
+  if (!bestRoute) {
+    return 'Live Bitflow route';
+  }
+
+  const tokenPath = bestRoute.tokenPath.length > 0
+    ? bestRoute.tokenPath.map(formatTokenLabel).join(' → ')
+    : 'STX → USDA';
+  const dexPath = bestRoute.dexPath.length > 0
+    ? bestRoute.dexPath.map(formatDexLabel).join(' / ')
+    : 'Bitflow';
+
+  return `${tokenPath} via ${dexPath}`;
+};

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -3,6 +3,7 @@
  */
 export { WalletConnect } from './WalletConnect';
 export { DepositCard } from './DepositCard';
+export { CollateralPreview } from './CollateralPreview';
 export { WithdrawCard } from './WithdrawCard';
 export { BorrowCard } from './BorrowCard';
 export { RepayCard } from './RepayCard';


### PR DESCRIPTION
This pull request introduces a live Bitflow collateral preview to the STX deposit flow, allowing users to see the estimated USDA value and route details before submitting their deposit. The main changes include the creation and integration of the `CollateralPreview` component, comprehensive unit tests for both the component and its utility functions, and updates to documentation and existing tests to reflect the new feature.

**New Collateral Preview Feature:**

- **Component Implementation:**
  - Added the `CollateralPreview` React component, which fetches a live Bitflow quote as the user enters an STX amount, debounces input, handles loading and error states, and displays estimated USDA value, route, and price impact.
  - Integrated the `CollateralPreview` component into the `DepositCard`, so the preview updates in real time as the user types. [[1]](diffhunk://#diff-0d6ed8c79716f5c7998033332f4f245e96ace1ea9cfd06ce51bdb6b9606efedfR8) [[2]](diffhunk://#diff-0d6ed8c79716f5c7998033332f4f245e96ace1ea9cfd06ce51bdb6b9606efedfR101-R102) [[3]](diffhunk://#diff-0d6ed8c79716f5c7998033332f4f245e96ace1ea9cfd06ce51bdb6b9606efedfR158-R159)

**Testing and Utilities:**

- **Component and Utility Tests:**
  - Added unit tests for `CollateralPreview`, covering idle/loading/success/error states, debouncing, and user retry logic.
  - Added tests for utility functions in `collateralPreviewUtils`, such as amount normalization, output extraction, and label formatting.
  - Updated `DepositCard` tests to mock and verify the integration with `CollateralPreview`. [[1]](diffhunk://#diff-df35bef92db728fb421e4d0678ba724bb5131b52adb5fe0993d21a35d040125bR44-R49) [[2]](diffhunk://#diff-df35bef92db728fb421e4d0678ba724bb5131b52adb5fe0993d21a35d040125bR93-R97) [[3]](diffhunk://#diff-df35bef92db728fb421e4d0678ba724bb5131b52adb5fe0993d21a35d040125bR150-R159)

**Documentation Updates:**

- Updated `frontend/README.md` to document the new live Bitflow collateral preview feature and reference the new component file. [[1]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543R26) [[2]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543R41) [[3]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L72-R74)

These changes collectively enhance the user experience by providing immediate, actionable feedback during the deposit process.