### PR TITLE
Add live Bitflow token ticker to the dashboard

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,6 +6,8 @@ React-based web interface for the BitFlow Lend protocol on Stacks blockchain.
 
 Modern, responsive dashboard for depositing STX, borrowing against collateral, and managing loans with real-time protocol statistics and health monitoring.
 
+The dashboard also includes a live Bitflow token ticker at the top of the page so users can see current STX-adjacent swap rates without leaving the app.
+
 **Tech Stack:**
 - React 18 with TypeScript
 - Vite for fast development and optimized builds
@@ -155,6 +157,7 @@ frontend/
 - **Responsive Design:** Mobile-first, works on all screen sizes
 - **Wallet Integration:** Seamless connection with Hiro Wallet
 - **Real-time Updates:** Auto-refresh protocol stats every 30s
+- **Live Token Ticker:** Shows STX-adjacent Bitflow swap rates at the top of the dashboard and refreshes every 60 seconds
 - **Smart Polling:** Background updates pause when tab is hidden
 - **Accessibility:** WCAG-compliant with keyboard navigation
 
@@ -182,6 +185,7 @@ App
         └── Dashboard
             ├── WalletConnect
             ├── NetworkIndicator
+      ├── TokenRateTicker
             ├── StatsCard (x4)
             ├── DepositCard
             ├── BorrowCard

--- a/frontend/src/__tests__/integration.test.tsx
+++ b/frontend/src/__tests__/integration.test.tsx
@@ -219,6 +219,15 @@ describe('App Integration', () => {
       expect(screen.getByTestId('token-rate-ticker')).toBeInTheDocument();
     });
 
+    it('places the live token ticker above the protocol overview section', () => {
+      render(<Dashboard />);
+
+      const ticker = screen.getByTestId('token-rate-ticker');
+      const protocolOverview = screen.getByText('Protocol Overview');
+
+      expect(ticker.compareDocumentPosition(protocolOverview) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    });
+
     it('does not show action cards when disconnected', () => {
       render(<Dashboard />);
 

--- a/frontend/src/__tests__/integration.test.tsx
+++ b/frontend/src/__tests__/integration.test.tsx
@@ -18,6 +18,13 @@ const { mockOracleSanityState } = vi.hoisted(() => ({
   mockOracleSanityState: { current: { warning: false, deviation: 0 } },
 }));
 
+vi.mock('@bitflowlabs/core-sdk', () => ({
+  BitflowSDK: class {
+    getQuoteForRoute = vi.fn();
+    getAvailableTokens = vi.fn();
+  },
+}));
+
 // Mocks at module scope (hoisted)
 vi.mock('../hooks/useAuth', () => ({
   useAuth: () => mockAuthState.current,
@@ -132,6 +139,7 @@ vi.mock('lucide-react', () => ({
   ArrowDownCircle: () => <span>ArrowDown</span>,
   CheckCircle: () => <span>Check</span>,
   XCircle: () => <span>XCircle</span>,
+  Coins: () => <span>Coins</span>,
   ExternalLink: () => <span>ExtLink</span>,
   ArrowUpCircle: () => <span>ArrowUpCircle</span>,
   AlertTriangle: () => <span>Alert</span>,

--- a/frontend/src/__tests__/integration.test.tsx
+++ b/frontend/src/__tests__/integration.test.tsx
@@ -69,6 +69,10 @@ vi.mock('../hooks/useSmartPolling', () => ({
   useSmartPolling: vi.fn(),
 }));
 
+vi.mock('../components/TokenRateTicker', () => ({
+  TokenRateTicker: () => <div data-testid="token-rate-ticker">TokenRateTicker</div>,
+}));
+
 vi.mock('../config/contracts', () => ({
   ACTIVE_NETWORK: 'testnet',
   PROTOCOL_CONSTANTS: {
@@ -207,6 +211,12 @@ describe('App Integration', () => {
       render(<Dashboard />);
 
       expect(screen.getAllByText('Protocol Overview').length).toBeGreaterThan(0);
+    });
+
+    it('shows the live token ticker on the dashboard', () => {
+      render(<Dashboard />);
+
+      expect(screen.getByTestId('token-rate-ticker')).toBeInTheDocument();
     });
 
     it('does not show action cards when disconnected', () => {

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@ import { RepayCard } from './RepayCard';
 import { HealthMonitor } from './HealthMonitor';
 import { TransactionHistory } from './TransactionHistory';
 import { NetworkIndicator } from './NetworkIndicator';
+import { TokenRateTicker } from './TokenRateTicker';
 import { formatSTX } from '../utils/formatters';
 import { ACTIVE_NETWORK } from '../config/contracts';
 import { getHealthStatus } from '../utils/calculations';
@@ -136,6 +137,8 @@ export const Dashboard: React.FC = () => {
 
       {/* Main Content */}
       <main id="main-content" className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <TokenRateTicker />
+
         {/* Protocol Stats */}
         <section className="mb-8">
           <div className="flex items-center justify-between mb-5">

--- a/frontend/src/components/TokenRateTicker.tsx
+++ b/frontend/src/components/TokenRateTicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { Activity, RefreshCw, AlertTriangle } from 'lucide-react';
 import { useBitflowTokens } from '../hooks/useBitflowTokens';
@@ -63,55 +63,72 @@ export const TokenRateTicker: React.FC = () => {
   const [rates, setRates] = useState<TokenRateState[]>([]);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const refreshInFlightRef = useRef(false);
 
   const refreshRates = useCallback(async () => {
+    if (refreshInFlightRef.current) {
+      return;
+    }
+
+    refreshInFlightRef.current = true;
+
     if (tokens.length === 0) {
       setRates([]);
       setLastUpdated(null);
       setIsRefreshing(false);
+      refreshInFlightRef.current = false;
       return;
     }
 
     setIsRefreshing(true);
 
-    const settledRates = await Promise.allSettled(
-      tokens.map(async (token) => {
-        const quoteResult = await bitflow.getQuoteForRoute(token.tokenId, STX_TOKEN_ID, QUOTE_AMOUNT);
-        const rate = extractQuoteRate(quoteResult);
+    try {
+      const settledRates = await Promise.allSettled(
+        tokens.map(async (token) => {
+          const quoteResult = await bitflow.getQuoteForRoute(token.tokenId, STX_TOKEN_ID, QUOTE_AMOUNT);
+          const rate = extractQuoteRate(quoteResult);
 
-        if (rate === null) {
-          throw new Error('No live route is available right now.');
+          if (rate === null) {
+            throw new Error('No live route is available right now.');
+          }
+
+          return {
+            tokenId: token.tokenId,
+            name: getTokenLabel(token.name, token.tokenId),
+            rate,
+            routeLabel: getRouteLabel(quoteResult.bestRoute as PreviewRoute | null),
+            error: null,
+          } satisfies TokenRateState;
+        })
+      );
+
+      const nextRates = settledRates.map((result, index) => {
+        const token = tokens[index];
+
+        if (result.status === 'fulfilled') {
+          return result.value;
         }
 
         return {
           tokenId: token.tokenId,
           name: getTokenLabel(token.name, token.tokenId),
-          rate,
-          routeLabel: getRouteLabel(quoteResult.bestRoute as PreviewRoute | null),
-          error: null,
+          rate: null,
+          routeLabel: 'Bitflow live route unavailable',
+          error: getErrorMessage(result.reason, 'Unable to load live Bitflow rate.'),
         } satisfies TokenRateState;
-      })
-    );
+      });
 
-    const nextRates = settledRates.map((result, index) => {
-      const token = tokens[index];
+      const hasSuccessfulRate = nextRates.some((rate) => rate.rate !== null);
 
-      if (result.status === 'fulfilled') {
-        return result.value;
+      setRates(nextRates);
+
+      if (hasSuccessfulRate) {
+        setLastUpdated(new Date());
       }
-
-      return {
-        tokenId: token.tokenId,
-        name: getTokenLabel(token.name, token.tokenId),
-        rate: null,
-        routeLabel: 'Bitflow live route unavailable',
-        error: getErrorMessage(result.reason, 'Unable to load live Bitflow rate.'),
-      } satisfies TokenRateState;
-    });
-
-    setRates(nextRates);
-    setLastUpdated(new Date());
-    setIsRefreshing(false);
+    } finally {
+      setIsRefreshing(false);
+      refreshInFlightRef.current = false;
+    }
   }, [tokens]);
 
   useSmartPolling(refreshRates, REFRESH_INTERVAL_MS, tokens.length > 0 && !error);
@@ -126,6 +143,7 @@ export const TokenRateTicker: React.FC = () => {
     setIsRefreshing(false);
   }, [error]);
 
+  const isQuoteLoading = tokens.length > 0 && rates.length === 0;
   const hasRates = rates.length > 0;
 
   return (
@@ -150,7 +168,7 @@ export const TokenRateTicker: React.FC = () => {
         </div>
 
         <div className="border-t border-white/10 px-5 py-4">
-          {loading ? (
+          {loading || isQuoteLoading ? (
             <TickerSkeleton />
           ) : error ? (
             <div className="flex items-center gap-3 rounded-2xl border border-amber-400/20 bg-amber-400/10 px-4 py-4 text-sm text-amber-100">

--- a/frontend/src/components/TokenRateTicker.tsx
+++ b/frontend/src/components/TokenRateTicker.tsx
@@ -1,0 +1,201 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { Activity, RefreshCw, AlertTriangle } from 'lucide-react';
+import { useBitflowTokens } from '../hooks/useBitflowTokens';
+import { useSmartPolling } from '../hooks/useSmartPolling';
+import { formatSTX } from '../utils/formatters';
+import { extractEstimatedOutput, getRouteLabel, type PreviewRoute } from './collateralPreviewUtils';
+
+type QuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
+
+interface TokenRateState {
+  tokenId: string;
+  name: string;
+  rate: number | null;
+  routeLabel: string;
+  error: string | null;
+}
+
+const bitflow = new BitflowSDK();
+const STX_TOKEN_ID = 'token-stx';
+const REFRESH_INTERVAL_MS = 60_000;
+const QUOTE_AMOUNT = 1;
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+const extractQuoteRate = (quoteResult: QuoteResult): number | null => {
+  const bestRoute = quoteResult.bestRoute as PreviewRoute | null;
+  return extractEstimatedOutput(bestRoute);
+};
+
+const getTokenLabel = (name: string | undefined, tokenId: string): string => {
+  const trimmedName = typeof name === 'string' && name.trim().length > 0 ? name.trim() : '';
+  return trimmedName || tokenId;
+};
+
+const TickerSkeleton = () => (
+  <div className="flex gap-3 overflow-x-auto pb-1">
+    {Array.from({ length: 3 }).map((_, index) => (
+      <div
+        key={index}
+        className="min-w-[12rem] shrink-0 rounded-2xl border border-white/10 bg-white/5 px-4 py-4 animate-pulse"
+      >
+        <div className="h-3 w-20 rounded-full bg-white/10" />
+        <div className="mt-3 h-6 w-28 rounded-full bg-white/10" />
+        <div className="mt-2 h-3 w-full rounded-full bg-white/10" />
+        <div className="mt-2 h-3 w-5/6 rounded-full bg-white/10" />
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * Compact ticker that shows live Bitflow swap quotes against STX.
+ */
+export const TokenRateTicker: React.FC = () => {
+  const { tokens, loading, error } = useBitflowTokens();
+  const [rates, setRates] = useState<TokenRateState[]>([]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const refreshRates = useCallback(async () => {
+    if (tokens.length === 0) {
+      setRates([]);
+      setLastUpdated(null);
+      setIsRefreshing(false);
+      return;
+    }
+
+    setIsRefreshing(true);
+
+    const settledRates = await Promise.allSettled(
+      tokens.map(async (token) => {
+        const quoteResult = await bitflow.getQuoteForRoute(token.tokenId, STX_TOKEN_ID, QUOTE_AMOUNT);
+        const rate = extractQuoteRate(quoteResult);
+
+        if (rate === null) {
+          throw new Error('No live route is available right now.');
+        }
+
+        return {
+          tokenId: token.tokenId,
+          name: getTokenLabel(token.name, token.tokenId),
+          rate,
+          routeLabel: getRouteLabel(quoteResult.bestRoute as PreviewRoute | null),
+          error: null,
+        } satisfies TokenRateState;
+      })
+    );
+
+    const nextRates = settledRates.map((result, index) => {
+      const token = tokens[index];
+
+      if (result.status === 'fulfilled') {
+        return result.value;
+      }
+
+      return {
+        tokenId: token.tokenId,
+        name: getTokenLabel(token.name, token.tokenId),
+        rate: null,
+        routeLabel: 'Bitflow live route unavailable',
+        error: getErrorMessage(result.reason, 'Unable to load live Bitflow rate.'),
+      } satisfies TokenRateState;
+    });
+
+    setRates(nextRates);
+    setLastUpdated(new Date());
+    setIsRefreshing(false);
+  }, [tokens]);
+
+  useSmartPolling(refreshRates, REFRESH_INTERVAL_MS, tokens.length > 0 && !error);
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+
+    setRates([]);
+    setLastUpdated(null);
+    setIsRefreshing(false);
+  }, [error]);
+
+  const hasRates = rates.length > 0;
+
+  return (
+    <section className="mb-8" aria-label="Bitflow live token rates">
+      <div className="overflow-hidden rounded-3xl border border-gray-200/70 bg-gradient-to-r from-slate-950 via-slate-900 to-slate-950 text-white shadow-elevated">
+        <div className="flex flex-col gap-4 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-white/10 ring-1 ring-white/10">
+              <Activity size={18} aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Live Bitflow ticker</p>
+              <h3 className="text-lg font-semibold tracking-tight text-white">Swap rates against STX</h3>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 text-xs text-slate-300">
+            {isRefreshing && <RefreshCw size={13} className="animate-spin" aria-hidden="true" />}
+            <span>{isRefreshing ? 'Refreshing' : 'Live'}</span>
+            {lastUpdated && <span>Updated {lastUpdated.toLocaleTimeString()}</span>}
+          </div>
+        </div>
+
+        <div className="border-t border-white/10 px-5 py-4">
+          {loading ? (
+            <TickerSkeleton />
+          ) : error ? (
+            <div className="flex items-center gap-3 rounded-2xl border border-amber-400/20 bg-amber-400/10 px-4 py-4 text-sm text-amber-100">
+              <AlertTriangle size={16} className="shrink-0 text-amber-300" aria-hidden="true" />
+              <span>{error}</span>
+            </div>
+          ) : !hasRates ? (
+            <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4 text-sm text-slate-300">
+              No STX-adjacent Bitflow tokens are available right now.
+            </div>
+          ) : (
+            <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-thin" aria-live="polite">
+              {rates.map((rate) => (
+                <div
+                  key={rate.tokenId}
+                  className="min-w-[12rem] shrink-0 rounded-2xl border border-white/10 bg-white/5 px-4 py-4 shadow-sm shadow-black/10"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-semibold text-white">{rate.name}</span>
+                    <span className="rounded-full bg-emerald-500/15 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-300">
+                      STX
+                    </span>
+                  </div>
+
+                  <p className="mt-3 text-2xl font-semibold tracking-tight text-white">
+                    {rate.rate !== null ? `${formatSTX(rate.rate, 4)} STX` : 'Unavailable'}
+                  </p>
+
+                  <p className="mt-2 text-xs text-slate-300">
+                    {rate.rate !== null
+                      ? `1 ${rate.name} ≈ ${formatSTX(rate.rate, 4)} STX`
+                      : rate.error ?? 'Live route unavailable'}
+                  </p>
+
+                  <p className="mt-2 truncate text-[11px] leading-relaxed text-slate-400">
+                    {rate.routeLabel}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TokenRateTicker;

--- a/frontend/src/components/TokenRateTicker.tsx
+++ b/frontend/src/components/TokenRateTicker.tsx
@@ -206,7 +206,7 @@ export const TokenRateTicker: React.FC = () => {
             </div>
           ) : !hasRates ? (
             <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4 text-sm text-slate-300">
-              No STX-adjacent Bitflow tokens are available right now.
+              Bitflow did not return any STX-adjacent tokens for quoting right now.
             </div>
           ) : (
             <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-thin" aria-live="polite">

--- a/frontend/src/components/TokenRateTicker.tsx
+++ b/frontend/src/components/TokenRateTicker.tsx
@@ -3,6 +3,7 @@ import { BitflowSDK } from '@bitflowlabs/core-sdk';
 import { Activity, RefreshCw, AlertTriangle } from 'lucide-react';
 import { useBitflowTokens } from '../hooks/useBitflowTokens';
 import { useSmartPolling } from '../hooks/useSmartPolling';
+import { formatBitflowTokenLabel } from '../utils/bitflowTokens';
 import { formatSTX } from '../utils/formatters';
 import { extractEstimatedOutput, getRouteLabel, type PreviewRoute } from './collateralPreviewUtils';
 
@@ -36,11 +37,6 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
 const extractQuoteRate = (quoteResult: QuoteResult): number | null => {
   const bestRoute = quoteResult.bestRoute as PreviewRoute | null;
   return extractEstimatedOutput(bestRoute);
-};
-
-const getTokenLabel = (name: string | undefined, tokenId: string): string => {
-  const trimmedName = typeof name === 'string' && name.trim().length > 0 ? name.trim() : '';
-  return trimmedName || tokenId;
 };
 
 const TickerSkeleton = () => (
@@ -123,7 +119,7 @@ export const TokenRateTicker: React.FC = () => {
 
           return {
             tokenId: token.tokenId,
-            name: getTokenLabel(token.name, token.tokenId),
+            name: formatBitflowTokenLabel(token.name, token.tokenId),
             rate,
             routeLabel: getRouteLabel(quoteResult.bestRoute as PreviewRoute | null),
             error: null,
@@ -140,7 +136,7 @@ export const TokenRateTicker: React.FC = () => {
 
         return {
           tokenId: token.tokenId,
-          name: getTokenLabel(token.name, token.tokenId),
+          name: formatBitflowTokenLabel(token.name, token.tokenId),
           rate: null,
           routeLabel: 'Bitflow live route unavailable',
           error: getErrorMessage(result.reason, 'Unable to load live Bitflow rate.'),

--- a/frontend/src/components/TokenRateTicker.tsx
+++ b/frontend/src/components/TokenRateTicker.tsx
@@ -16,6 +16,10 @@ interface TokenRateState {
   error: string | null;
 }
 
+interface TokenRateCardProps {
+  rate: TokenRateState;
+}
+
 const bitflow = new BitflowSDK();
 const STX_TOKEN_ID = 'token-stx';
 const REFRESH_INTERVAL_MS = 60_000;
@@ -52,6 +56,31 @@ const TickerSkeleton = () => (
         <div className="mt-2 h-3 w-5/6 rounded-full bg-white/10" />
       </div>
     ))}
+  </div>
+);
+
+const TokenRateCard: React.FC<TokenRateCardProps> = ({ rate }) => (
+  <div className="min-w-[12rem] shrink-0 rounded-2xl border border-white/10 bg-white/5 px-4 py-4 shadow-sm shadow-black/10">
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm font-semibold text-white">{rate.name}</span>
+      <span className="rounded-full bg-emerald-500/15 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-300">
+        STX
+      </span>
+    </div>
+
+    <p className="mt-3 text-2xl font-semibold tracking-tight text-white">
+      {rate.rate !== null ? `${formatSTX(rate.rate, 4)} STX` : 'Unavailable'}
+    </p>
+
+    <p className="mt-2 text-xs text-slate-300">
+      {rate.rate !== null
+        ? `1 ${rate.name} ≈ ${formatSTX(rate.rate, 4)} STX`
+        : rate.error ?? 'Live route unavailable'}
+    </p>
+
+    <p className="mt-2 truncate text-[11px] leading-relaxed text-slate-400">
+      {rate.routeLabel}
+    </p>
   </div>
 );
 
@@ -182,31 +211,7 @@ export const TokenRateTicker: React.FC = () => {
           ) : (
             <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-thin" aria-live="polite">
               {rates.map((rate) => (
-                <div
-                  key={rate.tokenId}
-                  className="min-w-[12rem] shrink-0 rounded-2xl border border-white/10 bg-white/5 px-4 py-4 shadow-sm shadow-black/10"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-semibold text-white">{rate.name}</span>
-                    <span className="rounded-full bg-emerald-500/15 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-300">
-                      STX
-                    </span>
-                  </div>
-
-                  <p className="mt-3 text-2xl font-semibold tracking-tight text-white">
-                    {rate.rate !== null ? `${formatSTX(rate.rate, 4)} STX` : 'Unavailable'}
-                  </p>
-
-                  <p className="mt-2 text-xs text-slate-300">
-                    {rate.rate !== null
-                      ? `1 ${rate.name} ≈ ${formatSTX(rate.rate, 4)} STX`
-                      : rate.error ?? 'Live route unavailable'}
-                  </p>
-
-                  <p className="mt-2 truncate text-[11px] leading-relaxed text-slate-400">
-                    {rate.routeLabel}
-                  </p>
-                </div>
+                <TokenRateCard key={rate.tokenId} rate={rate} />
               ))}
             </div>
           )}

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -167,6 +167,15 @@ describe('Dashboard Component', () => {
       render(<Dashboard />);
       expect(screen.getByTestId('token-rate-ticker')).toBeInTheDocument();
     });
+
+    it('renders the token rate ticker before the protocol overview section', () => {
+      render(<Dashboard />);
+
+      const ticker = screen.getByTestId('token-rate-ticker');
+      const protocolOverview = screen.getByText('Protocol Overview');
+
+      expect(ticker.compareDocumentPosition(protocolOverview) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    });
   });
 
   describe('Protocol Stats (disconnected)', () => {

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -41,6 +41,10 @@ vi.mock('../NetworkIndicator', () => ({
   NetworkIndicator: () => <div data-testid="network-indicator">Network</div>,
 }));
 
+vi.mock('../TokenRateTicker', () => ({
+  TokenRateTicker: () => <div data-testid="token-rate-ticker">TokenRateTicker</div>,
+}));
+
 vi.mock('../LoadingCard', () => ({
   LoadingStats: () => <div data-testid="loading-stats">Loading...</div>,
 }));
@@ -157,6 +161,11 @@ describe('Dashboard Component', () => {
     it('renders the network indicator', () => {
       render(<Dashboard />);
       expect(screen.getByTestId('network-indicator')).toBeInTheDocument();
+    });
+
+    it('renders the token rate ticker', () => {
+      render(<Dashboard />);
+      expect(screen.getByTestId('token-rate-ticker')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/__tests__/TokenRateTicker.test.tsx
+++ b/frontend/src/components/__tests__/TokenRateTicker.test.tsx
@@ -44,7 +44,6 @@ const createQuote = (quote: number, tokenPath: string[]): QuoteResult => ({
       tokenYDecimals: 6,
     },
     quote,
-    tokenYAmount: quote,
     params: {},
     quoteData: {
       contract: 'SP000.mock-router',
@@ -79,7 +78,7 @@ const flushPromises = async () => {
 describe('TokenRateTicker', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
+    vi.useRealTimers();
 
     Object.defineProperty(document, 'visibilityState', {
       writable: true,
@@ -106,10 +105,12 @@ describe('TokenRateTicker', () => {
   });
 
   it('renders live quotes and refreshes them on the polling interval', async () => {
+    vi.useFakeTimers();
+
     mockUseBitflowTokens.mockReturnValue({
       tokens: [
-        { tokenId: 'token-usda', name: 'USDA', decimals: 6 },
-        { tokenId: 'token-stxbtc', name: 'STXBTC', decimals: 6 },
+        { tokenId: 'token-usda', name: 'USDA' },
+        { tokenId: 'token-stxbtc', name: 'STXBTC' },
       ],
       loading: false,
       error: null,
@@ -117,15 +118,15 @@ describe('TokenRateTicker', () => {
 
     mockGetQuoteForRoute
       .mockResolvedValueOnce(createQuote(1.02, ['token-usda', 'token-stx']))
-      .mockResolvedValueOnce(createQuote(0.0045, ['token-stxbtc', 'token-stx']))
+      .mockResolvedValueOnce(createQuote(0.0145, ['token-stxbtc', 'token-stx']))
       .mockResolvedValueOnce(createQuote(1.01, ['token-usda', 'token-stx']))
-      .mockResolvedValueOnce(createQuote(0.0048, ['token-stxbtc', 'token-stx']));
+      .mockResolvedValueOnce(createQuote(0.0148, ['token-stxbtc', 'token-stx']));
 
     render(<TokenRateTicker />);
 
-    await waitFor(() => {
-      expect(screen.getByText('1.0200 STX')).toBeInTheDocument();
-    });
+    await flushPromises();
+
+    expect(screen.getByText('1.0200 STX')).toBeInTheDocument();
 
     expect(screen.getByText('USDA')).toBeInTheDocument();
     expect(screen.getByText('STXBTC')).toBeInTheDocument();
@@ -142,19 +143,19 @@ describe('TokenRateTicker', () => {
 
     expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(4);
     expect(screen.getByText('1.0100 STX')).toBeInTheDocument();
-    expect(screen.getByText('0.0048 STX')).toBeInTheDocument();
+    expect(screen.getByText('0.0148 STX')).toBeInTheDocument();
   });
 
   it('shows a refreshing badge while the first live quote batch is still pending', async () => {
     mockUseBitflowTokens.mockReturnValue({
       tokens: [
-        { tokenId: 'token-usda', name: 'USDA', decimals: 6 },
+        { tokenId: 'token-usda', name: 'USDA' },
       ],
       loading: false,
       error: null,
     });
 
-    let resolveQuote: ((value: QuoteResult) => void) | null = null;
+    let resolveQuote: (value: QuoteResult) => void = () => undefined;
     const pendingQuote = new Promise<QuoteResult>((resolve) => {
       resolveQuote = resolve;
     });
@@ -167,7 +168,7 @@ describe('TokenRateTicker', () => {
       expect(screen.getByText('Refreshing')).toBeInTheDocument();
     });
 
-    resolveQuote?.(createQuote(1.02, ['token-usda', 'token-stx']));
+    resolveQuote(createQuote(1.02, ['token-usda', 'token-stx']));
 
     await flushPromises();
 
@@ -188,6 +189,26 @@ describe('TokenRateTicker', () => {
     expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
   });
 
+  it('formats missing token names into a readable fallback label', async () => {
+    mockUseBitflowTokens.mockReturnValue({
+      tokens: [
+        { tokenId: 'token-stxflow', name: '' },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    mockGetQuoteForRoute.mockResolvedValue(createQuote(0.5555, ['token-stxflow', 'token-stx']));
+
+    render(<TokenRateTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText('STXFLOW')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('0.5555 STX')).toBeInTheDocument();
+  });
+
   it('shows a helpful empty state when Bitflow returns no STX-adjacent tokens', () => {
     mockUseBitflowTokens.mockReturnValue({
       tokens: [],
@@ -204,7 +225,7 @@ describe('TokenRateTicker', () => {
   it('keeps the timestamp blank when every quote request fails', async () => {
     mockUseBitflowTokens.mockReturnValue({
       tokens: [
-        { tokenId: 'token-usda', name: 'USDA', decimals: 6 },
+        { tokenId: 'token-usda', name: 'USDA' },
       ],
       loading: false,
       error: null,

--- a/frontend/src/components/__tests__/TokenRateTicker.test.tsx
+++ b/frontend/src/components/__tests__/TokenRateTicker.test.tsx
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { TokenRateTicker } from '../TokenRateTicker';
+
+const mockGetQuoteForRoute = vi.hoisted(() => vi.fn());
+const mockUseBitflowTokens = vi.hoisted(() => vi.fn());
+
+vi.mock('@bitflowlabs/core-sdk', () => ({
+  BitflowSDK: class {
+    getQuoteForRoute = mockGetQuoteForRoute;
+  },
+}));
+
+vi.mock('../../hooks/useBitflowTokens', () => ({
+  useBitflowTokens: () => mockUseBitflowTokens(),
+}));
+
+vi.mock('lucide-react', () => ({
+  Activity: () => <span>Activity</span>,
+  RefreshCw: () => <span>RefreshCw</span>,
+  AlertTriangle: () => <span>AlertTriangle</span>,
+}));
+
+type QuoteResult = Awaited<ReturnType<BitflowSDK['getQuoteForRoute']>>;
+
+const createQuote = (quote: number, tokenPath: string[]): QuoteResult => ({
+  bestRoute: {
+    route: {
+      dex_path: ['alex'],
+      token_path: tokenPath,
+      postConditions: {},
+      quoteData: {
+        contract: 'SP000.mock-router',
+        function: 'quote',
+        parameters: {},
+      },
+      swapData: {
+        contract: 'SP000.mock-router',
+        function: 'swap',
+        parameters: {},
+      },
+      tokenXDecimals: 6,
+      tokenYDecimals: 6,
+    },
+    quote,
+    tokenYAmount: quote,
+    params: {},
+    quoteData: {
+      contract: 'SP000.mock-router',
+      function: 'quote',
+      parameters: {},
+    },
+    swapData: {
+      contract: 'SP000.mock-router',
+      function: 'swap',
+      parameters: {},
+    },
+    dexPath: ['alex'],
+    tokenPath,
+    tokenXDecimals: 6,
+    tokenYDecimals: 6,
+  },
+  allRoutes: [],
+  inputData: {
+    tokenX: tokenPath[0],
+    tokenY: tokenPath[tokenPath.length - 1],
+    amountInput: 1,
+  },
+});
+
+const flushPromises = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('TokenRateTicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    Object.defineProperty(document, 'visibilityState', {
+      writable: true,
+      value: 'visible',
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the loading skeleton while Bitflow tokens are being discovered', () => {
+    mockUseBitflowTokens.mockReturnValue({
+      tokens: [],
+      loading: true,
+      error: null,
+    });
+
+    const { container } = render(<TokenRateTicker />);
+
+    expect(screen.getByText('Swap rates against STX')).toBeInTheDocument();
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
+  });
+
+  it('renders live quotes and refreshes them on the polling interval', async () => {
+    mockUseBitflowTokens.mockReturnValue({
+      tokens: [
+        { tokenId: 'token-usda', name: 'USDA', decimals: 6 },
+        { tokenId: 'token-stxbtc', name: 'STXBTC', decimals: 6 },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    mockGetQuoteForRoute
+      .mockResolvedValueOnce(createQuote(1.02, ['token-usda', 'token-stx']))
+      .mockResolvedValueOnce(createQuote(0.0045, ['token-stxbtc', 'token-stx']))
+      .mockResolvedValueOnce(createQuote(1.01, ['token-usda', 'token-stx']))
+      .mockResolvedValueOnce(createQuote(0.0048, ['token-stxbtc', 'token-stx']));
+
+    render(<TokenRateTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1.0200 STX')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('USDA')).toBeInTheDocument();
+    expect(screen.getByText('STXBTC')).toBeInTheDocument();
+    expect(screen.getByText(/USDA → STX via ALEX/i)).toBeInTheDocument();
+    expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-usda', 'token-stx', 1);
+    expect(mockGetQuoteForRoute).toHaveBeenCalledWith('token-stxbtc', 'token-stx', 1);
+    expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    await flushPromises();
+
+    expect(mockGetQuoteForRoute).toHaveBeenCalledTimes(4);
+    expect(screen.getByText('1.0100 STX')).toBeInTheDocument();
+    expect(screen.getByText('0.0048 STX')).toBeInTheDocument();
+  });
+
+  it('shows a readable error when Bitflow token discovery fails', () => {
+    mockUseBitflowTokens.mockReturnValue({
+      tokens: [],
+      loading: false,
+      error: 'Bitflow unavailable',
+    });
+
+    render(<TokenRateTicker />);
+
+    expect(screen.getByText('Bitflow unavailable')).toBeInTheDocument();
+    expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/TokenRateTicker.test.tsx
+++ b/frontend/src/components/__tests__/TokenRateTicker.test.tsx
@@ -145,6 +145,36 @@ describe('TokenRateTicker', () => {
     expect(screen.getByText('0.0048 STX')).toBeInTheDocument();
   });
 
+  it('shows a refreshing badge while the first live quote batch is still pending', async () => {
+    mockUseBitflowTokens.mockReturnValue({
+      tokens: [
+        { tokenId: 'token-usda', name: 'USDA', decimals: 6 },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    let resolveQuote: ((value: QuoteResult) => void) | null = null;
+    const pendingQuote = new Promise<QuoteResult>((resolve) => {
+      resolveQuote = resolve;
+    });
+
+    mockGetQuoteForRoute.mockReturnValue(pendingQuote);
+
+    render(<TokenRateTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Refreshing')).toBeInTheDocument();
+    });
+
+    resolveQuote?.(createQuote(1.02, ['token-usda', 'token-stx']));
+
+    await flushPromises();
+
+    expect(screen.getByText('Live')).toBeInTheDocument();
+    expect(screen.getByText('1.0200 STX')).toBeInTheDocument();
+  });
+
   it('shows a readable error when Bitflow token discovery fails', () => {
     mockUseBitflowTokens.mockReturnValue({
       tokens: [],

--- a/frontend/src/components/__tests__/TokenRateTicker.test.tsx
+++ b/frontend/src/components/__tests__/TokenRateTicker.test.tsx
@@ -188,6 +188,19 @@ describe('TokenRateTicker', () => {
     expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
   });
 
+  it('shows a helpful empty state when Bitflow returns no STX-adjacent tokens', () => {
+    mockUseBitflowTokens.mockReturnValue({
+      tokens: [],
+      loading: false,
+      error: null,
+    });
+
+    render(<TokenRateTicker />);
+
+    expect(screen.getByText('Bitflow did not return any STX-adjacent tokens for quoting right now.')).toBeInTheDocument();
+    expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
+  });
+
   it('keeps the timestamp blank when every quote request fails', async () => {
     mockUseBitflowTokens.mockReturnValue({
       tokens: [

--- a/frontend/src/components/__tests__/TokenRateTicker.test.tsx
+++ b/frontend/src/components/__tests__/TokenRateTicker.test.tsx
@@ -157,4 +157,25 @@ describe('TokenRateTicker', () => {
     expect(screen.getByText('Bitflow unavailable')).toBeInTheDocument();
     expect(mockGetQuoteForRoute).not.toHaveBeenCalled();
   });
+
+  it('keeps the timestamp blank when every quote request fails', async () => {
+    mockUseBitflowTokens.mockReturnValue({
+      tokens: [
+        { tokenId: 'token-usda', name: 'USDA', decimals: 6 },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    mockGetQuoteForRoute.mockRejectedValue(new Error('No route available'));
+
+    render(<TokenRateTicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No route available')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText(/Updated /i)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -13,6 +13,7 @@ export { StatsCard } from './StatsCard';
 export { TransactionHistory } from './TransactionHistory';
 export { LiquidationList } from './LiquidationList';
 export { NetworkIndicator } from './NetworkIndicator';
+export { TokenRateTicker } from './TokenRateTicker';
 export { ToastProvider, useToastContext } from './ToastProvider';
 export { ToastContainer } from './Toast';
 export { LoadingCard, LoadingStats } from './LoadingCard';

--- a/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
+++ b/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
@@ -31,6 +31,7 @@ describe('useBitflowTokens', () => {
       createToken('token-wstx', 'wSTX'),
       createToken('token-stxbtc', 'STXBTC'),
       createToken('token-stxusd', 'STXUSD'),
+      createToken('token-stxusd', 'STXUSD duplicate'),
       createToken('token-stxflow', 'STXFLOW'),
       createToken('token-btc', 'BTC'),
     ]);

--- a/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
+++ b/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { useBitflowTokens } from '../useBitflowTokens';
+
+const mockGetAvailableTokens = vi.hoisted(() => vi.fn());
+
+vi.mock('@bitflowlabs/core-sdk', () => ({
+  BitflowSDK: class {
+    getAvailableTokens = mockGetAvailableTokens;
+  },
+}));
+
+type AvailableToken = Awaited<ReturnType<BitflowSDK['getAvailableTokens']>>[number];
+
+const createToken = (tokenId: string, name: string): AvailableToken => ({
+  tokenId,
+  name,
+  decimals: 6,
+});
+
+describe('useBitflowTokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters STX-adjacent tokens and caps the list at five entries', async () => {
+    mockGetAvailableTokens.mockResolvedValue([
+      createToken('token-stx', 'STX'),
+      createToken('token-usda', 'USDA'),
+      createToken('token-wstx', 'wSTX'),
+      createToken('token-stxbtc', 'STXBTC'),
+      createToken('token-stxusd', 'STXUSD'),
+      createToken('token-stxflow', 'STXFLOW'),
+      createToken('token-btc', 'BTC'),
+    ]);
+
+    const { result } = renderHook(() => useBitflowTokens());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.tokens.map((token) => token.tokenId)).toEqual([
+      'token-stx',
+      'token-usda',
+      'token-wstx',
+      'token-stxbtc',
+      'token-stxusd',
+    ]);
+    expect(mockGetAvailableTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a readable error when Bitflow token discovery fails', async () => {
+    mockGetAvailableTokens.mockRejectedValue(new Error('Bitflow unavailable'));
+
+    const { result } = renderHook(() => useBitflowTokens());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.tokens).toEqual([]);
+    expect(result.current.error).toBe('Bitflow unavailable');
+  });
+});

--- a/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
+++ b/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
@@ -16,8 +16,7 @@ type AvailableToken = Awaited<ReturnType<BitflowSDK['getAvailableTokens']>>[numb
 const createToken = (tokenId: string, name: string): AvailableToken => ({
   tokenId,
   name,
-  decimals: 6,
-});
+} as AvailableToken);
 
 describe('useBitflowTokens', () => {
   beforeEach(() => {

--- a/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
+++ b/frontend/src/hooks/__tests__/useBitflowTokens.test.ts
@@ -45,10 +45,10 @@ describe('useBitflowTokens', () => {
     expect(result.current.error).toBeNull();
     expect(result.current.tokens.map((token) => token.tokenId)).toEqual([
       'token-stx',
-      'token-usda',
-      'token-wstx',
       'token-stxbtc',
+      'token-stxflow',
       'token-stxusd',
+      'token-usda',
     ]);
     expect(mockGetAvailableTokens).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useStxPrice } from './useStxPrice';
 export { useOracleSanityCheck } from './useOracleSanityCheck';
 export { useToast } from './useToast';
 export { useProtocolStats } from './useProtocolStats';
+export { useBitflowTokens } from './useBitflowTokens';

--- a/frontend/src/hooks/useBitflowTokens.ts
+++ b/frontend/src/hooks/useBitflowTokens.ts
@@ -12,6 +12,11 @@ interface UseBitflowTokensResult {
 const bitflow = new BitflowSDK();
 const MAX_TOKENS = 5;
 
+const getTokenLabel = (name: string | undefined, tokenId: string): string => {
+  const trimmedName = typeof name === 'string' && name.trim().length > 0 ? name.trim() : '';
+  return trimmedName || tokenId;
+};
+
 const getErrorMessage = (error: unknown, fallback: string): string => {
   if (error instanceof Error && error.message) {
     return error.message;
@@ -53,6 +58,12 @@ export function useBitflowTokens(): UseBitflowTokensResult {
 
             seenTokenIds.add(token.tokenId);
             return true;
+          })
+          .sort((left, right) => {
+            const leftLabel = getTokenLabel(left.name, left.tokenId);
+            const rightLabel = getTokenLabel(right.name, right.tokenId);
+
+            return leftLabel.localeCompare(rightLabel);
           })
           .slice(0, MAX_TOKENS);
 

--- a/frontend/src/hooks/useBitflowTokens.ts
+++ b/frontend/src/hooks/useBitflowTokens.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { BitflowSDK } from '@bitflowlabs/core-sdk';
+
+export type BitflowToken = Awaited<ReturnType<BitflowSDK['getAvailableTokens']>>[number];
+
+interface UseBitflowTokensResult {
+  tokens: BitflowToken[];
+  loading: boolean;
+  error: string | null;
+}
+
+const bitflow = new BitflowSDK();
+const MAX_TOKENS = 5;
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+/**
+ * Loads the public Bitflow token list and keeps only the STX-adjacent tokens
+ * that are relevant to the dashboard ticker.
+ */
+export function useBitflowTokens(): UseBitflowTokensResult {
+  const [tokens, setTokens] = useState<BitflowToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const loadTokens = async () => {
+      try {
+        const availableTokens = await bitflow.getAvailableTokens();
+
+        if (!isActive) {
+          return;
+        }
+
+        const filteredTokens = availableTokens
+          .filter((token) => {
+            const tokenId = typeof token.tokenId === 'string' ? token.tokenId.toLowerCase() : '';
+            return tokenId.includes('stx') || tokenId.includes('usda');
+          })
+          .slice(0, MAX_TOKENS);
+
+        setTokens(filteredTokens);
+      } catch (fetchError: unknown) {
+        if (!isActive) {
+          return;
+        }
+
+        setTokens([]);
+        setError(getErrorMessage(fetchError, 'Failed to load Bitflow tokens'));
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadTokens();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  return { tokens, loading, error };
+}
+
+export default useBitflowTokens;

--- a/frontend/src/hooks/useBitflowTokens.ts
+++ b/frontend/src/hooks/useBitflowTokens.ts
@@ -40,10 +40,19 @@ export function useBitflowTokens(): UseBitflowTokensResult {
           return;
         }
 
+        const seenTokenIds = new Set<string>();
         const filteredTokens = availableTokens
           .filter((token) => {
             const tokenId = typeof token.tokenId === 'string' ? token.tokenId.toLowerCase() : '';
             return tokenId.includes('stx') || tokenId.includes('usda');
+          })
+          .filter((token) => {
+            if (seenTokenIds.has(token.tokenId)) {
+              return false;
+            }
+
+            seenTokenIds.add(token.tokenId);
+            return true;
           })
           .slice(0, MAX_TOKENS);
 

--- a/frontend/src/hooks/useBitflowTokens.ts
+++ b/frontend/src/hooks/useBitflowTokens.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { BitflowSDK } from '@bitflowlabs/core-sdk';
+import { formatBitflowTokenLabel } from '../utils/bitflowTokens';
 
 export type BitflowToken = Awaited<ReturnType<BitflowSDK['getAvailableTokens']>>[number];
 
@@ -11,11 +12,6 @@ interface UseBitflowTokensResult {
 
 const bitflow = new BitflowSDK();
 const MAX_TOKENS = 5;
-
-const getTokenLabel = (name: string | undefined, tokenId: string): string => {
-  const trimmedName = typeof name === 'string' && name.trim().length > 0 ? name.trim() : '';
-  return trimmedName || tokenId;
-};
 
 const getErrorMessage = (error: unknown, fallback: string): string => {
   if (error instanceof Error && error.message) {
@@ -60,8 +56,8 @@ export function useBitflowTokens(): UseBitflowTokensResult {
             return true;
           })
           .sort((left, right) => {
-            const leftLabel = getTokenLabel(left.name, left.tokenId);
-            const rightLabel = getTokenLabel(right.name, right.tokenId);
+            const leftLabel = formatBitflowTokenLabel(left.name, left.tokenId);
+            const rightLabel = formatBitflowTokenLabel(right.name, right.tokenId);
 
             return leftLabel.localeCompare(rightLabel);
           })

--- a/frontend/src/utils/bitflowTokens.ts
+++ b/frontend/src/utils/bitflowTokens.ts
@@ -1,0 +1,12 @@
+export const formatBitflowTokenLabel = (name: string | undefined, tokenId: string): string => {
+  const trimmedName = typeof name === 'string' && name.trim().length > 0 ? name.trim() : '';
+
+  if (trimmedName) {
+    return trimmedName;
+  }
+
+  return tokenId
+    .replace(/^token[-_]/i, '')
+    .replace(/[-_]/g, ' ')
+    .toUpperCase();
+};


### PR DESCRIPTION
## Summary
- Add a Bitflow token discovery hook that filters STX-adjacent tokens and limits the dashboard to five live entries.
- Render a compact live ticker at the top of the dashboard with swap quotes against STX.
- Refresh the ticker every 60 seconds and keep it isolated from the rest of the dashboard through test mocks.

## Validation
- npm test
- npm run build