### PR TITLE
Improve Stacks transaction confirmation lifecycle reliability

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Oracle registry now rejects `submit-price` updates when reporter count is below configured `min-reporters`
 - Vault v2 now uses a shared `calculate-outstanding-debt` path for health-factor, repayment quotes, and repay execution to eliminate debt drift
 - Vault v2 deposit cap enforcement now treats `DEPOSIT-LIMIT` as an inclusive upper bound and returns `u401` only when a deposit exceeds the cap
+- Frontend transaction confirmation now tracks Stacks lifecycle states via Hiro `GET /extended/v1/tx/{txId}` polling every 30 seconds, avoids false timeout failures, and only marks terminal not-found after a 60-minute grace window
 
 ### Security
 - Added reporter-threshold enforcement error path (`u400`) to prevent under-quorum aggregate updates

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -164,7 +164,9 @@ frontend/
 ### Smart Contract Integration
 - **Read-Only Calls:** Fetch user deposits, loans, and protocol stats
 - **Transactions:** Deposit, borrow, repay, and withdraw with post-conditions
-- **Transaction Polling:** Monitor pending transactions until confirmed
+- **Transaction Confirmation Lifecycle:** Uses Hiro `GET /extended/v1/tx/{txId}` polling every 30 seconds with no fixed timeout cap
+- **Stacks-Aware Status Messaging:** Shows mempool confirmation progress, successful confirmation, and post-condition rejection states
+- **Graceful Not Found Handling:** Treats temporary `not_found` responses as propagation delay and only surfaces terminal not-found after 60 minutes
 - **Error Handling:** Clear error messages for all failure scenarios
 - **Oracle Sanity Checks:** Warn before borrowing or repaying when the oracle price diverges more than 5% from Bitflow's live STX/USDA quote
 

--- a/frontend/src/__tests__/integration.test.tsx
+++ b/frontend/src/__tests__/integration.test.tsx
@@ -186,7 +186,6 @@ describe('App Integration', () => {
       getUserLoan: vi.fn().mockResolvedValue(null),
       getHealthFactor: vi.fn().mockResolvedValue(null),
       getRepaymentAmount: vi.fn().mockResolvedValue(null),
-      pollTransactionStatus: vi.fn().mockResolvedValue('confirmed'),
       isLoading: false,
       error: null,
     };

--- a/frontend/src/components/StacksTxStatusPanel.tsx
+++ b/frontend/src/components/StacksTxStatusPanel.tsx
@@ -75,6 +75,12 @@ export const StacksTxStatusPanel: React.FC<StacksTxStatusPanelProps> = ({ snapsh
         </div>
       )}
 
+      {snapshot.state === 'not_found' && (
+        <div className={`text-xs ${variant.text}`}>
+          We kept polling for {formatDurationMinutes(snapshot.elapsedMs)} before marking this as not found.
+        </div>
+      )}
+
       {anchorLabel && (
         <div className={`text-xs ${variant.text}`}>
           Microblock anchor time: {anchorLabel}

--- a/frontend/src/components/StacksTxStatusPanel.tsx
+++ b/frontend/src/components/StacksTxStatusPanel.tsx
@@ -38,6 +38,10 @@ export const StacksTxStatusPanel: React.FC<StacksTxStatusPanelProps> = ({ snapsh
       : txStatusPalette.pending;
 
   const anchorLabel = formatUnixSeconds(snapshot.microblockAnchorTime);
+  const averageBlockTimeMinutes = snapshot.averageBlockTimeMinutes ?? 12.5;
+  const notFoundGraceRemaining = snapshot.notFoundGraceRemainingMs
+    ? formatDurationMinutes(snapshot.notFoundGraceRemainingMs)
+    : null;
 
   return (
     <div className={`p-3 rounded-xl border space-y-3 ${variant.panel}`} role="status" aria-live="polite">
@@ -49,7 +53,7 @@ export const StacksTxStatusPanel: React.FC<StacksTxStatusPanelProps> = ({ snapsh
       {snapshot.state === 'pending' && (
         <div className="space-y-2">
           <div className="flex justify-between text-xs text-amber-800">
-            <span>Estimated confirmation window: 10-15 min</span>
+            <span>Estimated by average Stacks block time: ~{averageBlockTimeMinutes} min</span>
             <span>{formatDurationMinutes(snapshot.elapsedMs)} elapsed</span>
           </div>
           <div className="h-2 bg-amber-100 rounded-full overflow-hidden" aria-hidden="true">
@@ -63,6 +67,11 @@ export const StacksTxStatusPanel: React.FC<StacksTxStatusPanelProps> = ({ snapsh
               ? `Approx. ${formatDurationMinutes(snapshot.remainingMs)} remaining based on average Stacks block time`
               : 'Confirmation is taking longer than average block time but still valid in mempool.'}
           </div>
+          {snapshot.pendingPhase === 'propagation' && notFoundGraceRemaining && (
+            <div className="text-xs text-amber-800">
+              Indexer propagation is still in progress. We will only mark this as not found after {notFoundGraceRemaining}.
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/__tests__/BorrowCard.test.tsx
+++ b/frontend/src/components/__tests__/BorrowCard.test.tsx
@@ -351,6 +351,56 @@ describe('BorrowCard Component', () => {
       });
     });
 
+    it('keeps tx pending while status is temporary not_found', async () => {
+      mockBorrow.mockResolvedValue({ success: true, txId: '0xabc' });
+      mockUseStacksTxStatus.mockReturnValue(buildTxSnapshot({
+        state: 'pending',
+        txStatusRaw: 'not_found',
+        pendingPhase: 'propagation',
+        message: 'Transaction submitted — waiting for indexer propagation...',
+        txId: '0xabc',
+        isPolling: true,
+        hasTerminalError: false,
+      }));
+
+      const user = userEvent.setup();
+      render(<BorrowCard />);
+
+      const input = screen.getByPlaceholderText('0.00');
+      await user.type(input, '50');
+
+      const submitBtn = screen.getByRole('button', { name: /Borrow STX/i });
+      await user.click(submitBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/waiting for indexer propagation/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows terminal rejection message for abort_by_response', async () => {
+      mockBorrow.mockResolvedValue({ success: true, txId: '0xabc' });
+      mockUseStacksTxStatus.mockReturnValue(buildTxSnapshot({
+        state: 'abort_by_response',
+        txStatusRaw: 'abort_by_response',
+        message: 'Transaction rejected — check post-conditions',
+        txId: '0xabc',
+        hasTerminalError: true,
+      }));
+
+      const user = userEvent.setup();
+      render(<BorrowCard />);
+
+      const input = screen.getByPlaceholderText('0.00');
+      await user.type(input, '50');
+
+      const submitBtn = screen.getByRole('button', { name: /Borrow STX/i });
+      await user.click(submitBtn);
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/Transaction rejected — check post-conditions/).length).toBeGreaterThan(0);
+      });
+    });
+
     it('disables borrow when no deposit', () => {
       mockGetUserDeposit.mockResolvedValue({ amountSTX: 0 });
       render(<BorrowCard />);

--- a/frontend/src/components/__tests__/DepositCard.test.tsx
+++ b/frontend/src/components/__tests__/DepositCard.test.tsx
@@ -309,6 +309,34 @@ describe('DepositCard Component', () => {
       });
     });
 
+    it('keeps pending state when tx is temporarily not_found during grace period', async () => {
+      mockDeposit.mockResolvedValue({ success: true, txId: '0xabc' });
+      mockUseStacksTxStatus.mockReturnValue(buildTxSnapshot({
+        state: 'pending',
+        txStatusRaw: 'not_found',
+        pendingPhase: 'propagation',
+        message: 'Transaction submitted — waiting for indexer propagation...',
+        txId: '0xabc',
+        isPolling: true,
+        hasTerminalError: false,
+      }));
+
+      const user = userEvent.setup();
+      render(<DepositCard />);
+
+      const input = screen.getByPlaceholderText('0.00');
+      await user.type(input, '10');
+
+      const submitBtn = screen.getByRole('button', { name: /Deposit STX/i });
+      await user.click(submitBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/waiting for indexer propagation/i)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/See transaction details below./i)).not.toBeInTheDocument();
+    });
+
     it('handles thrown errors gracefully', async () => {
       mockDeposit.mockRejectedValue(new Error('Network failure'));
       

--- a/frontend/src/components/__tests__/RepayCard.test.tsx
+++ b/frontend/src/components/__tests__/RepayCard.test.tsx
@@ -310,6 +310,56 @@ describe('RepayCard Component', () => {
       });
     });
 
+    it('keeps pending state for temporary not_found responses', async () => {
+      mockRepay.mockResolvedValue({ success: true, txId: '0xabc' });
+      mockUseStacksTxStatus.mockReturnValue(buildTxSnapshot({
+        state: 'pending',
+        txStatusRaw: 'not_found',
+        pendingPhase: 'propagation',
+        message: 'Transaction submitted — waiting for indexer propagation...',
+        txId: '0xabc',
+        hasTerminalError: false,
+        isPolling: true,
+      }));
+
+      const user = userEvent.setup();
+      render(<RepayCard />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Repay Loan/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Repay Loan/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/waiting for indexer propagation/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows terminal rejection when tx status is abort_by_response', async () => {
+      mockRepay.mockResolvedValue({ success: true, txId: '0xabc' });
+      mockUseStacksTxStatus.mockReturnValue(buildTxSnapshot({
+        state: 'abort_by_response',
+        txStatusRaw: 'abort_by_response',
+        message: 'Transaction rejected — check post-conditions',
+        txId: '0xabc',
+        hasTerminalError: true,
+      }));
+
+      const user = userEvent.setup();
+      render(<RepayCard />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Repay Loan/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Repay Loan/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/Transaction rejected — check post-conditions/).length).toBeGreaterThan(0);
+      });
+    });
+
     it('shows processing state during repay', async () => {
       mockRepay.mockReturnValue(new Promise(() => {})); // never resolves
       const user = userEvent.setup();

--- a/frontend/src/components/__tests__/StacksTxStatusPanel.test.tsx
+++ b/frontend/src/components/__tests__/StacksTxStatusPanel.test.tsx
@@ -37,7 +37,7 @@ describe('StacksTxStatusPanel', () => {
     render(<StacksTxStatusPanel snapshot={buildSnapshot()} />);
 
     expect(screen.getByText('Transaction in Stacks mempool — confirming with Bitcoin...')).toBeInTheDocument();
-    expect(screen.getByText(/average Stacks block time/i)).toBeInTheDocument();
+    expect(screen.getByText(/Estimated by average Stacks block time/i)).toBeInTheDocument();
     expect(screen.getByText(/Approx. 11 min remaining/i)).toBeInTheDocument();
   });
 

--- a/frontend/src/components/__tests__/StacksTxStatusPanel.test.tsx
+++ b/frontend/src/components/__tests__/StacksTxStatusPanel.test.tsx
@@ -88,6 +88,24 @@ describe('StacksTxStatusPanel', () => {
     expect(screen.getByText('Transaction rejected — check post-conditions')).toBeInTheDocument();
   });
 
+  it('explains not_found after long grace window', () => {
+    render(
+      <StacksTxStatusPanel
+        snapshot={buildSnapshot({
+          state: 'not_found',
+          txStatusRaw: 'not_found',
+          message: 'Transaction not found after 60 minutes. Confirm the tx ID in the explorer.',
+          elapsedMs: 61 * 60 * 1000,
+          hasTerminalError: true,
+          isPolling: false,
+        })}
+      />
+    );
+
+    expect(screen.getByText(/not found after 60 minutes/i)).toBeInTheDocument();
+    expect(screen.getByText(/kept polling for 61 min/i)).toBeInTheDocument();
+  });
+
   it('renders microblock anchor label when available', () => {
     render(
       <StacksTxStatusPanel

--- a/frontend/src/components/__tests__/StacksTxStatusPanel.test.tsx
+++ b/frontend/src/components/__tests__/StacksTxStatusPanel.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StacksTxStatusPanel } from '../StacksTxStatusPanel';
+import type { StacksTxStatusSnapshot } from '../../types/txStatus';
+
+vi.mock('../../config/contracts', () => ({
+  getExplorerUrl: (txId?: string) => `https://explorer.hiro.so/txid/${txId}`,
+}));
+
+vi.mock('lucide-react', () => ({
+  AlertCircle: () => <span>AlertCircle</span>,
+  CheckCircle: () => <span>CheckCircle</span>,
+  XCircle: () => <span>XCircle</span>,
+  ExternalLink: () => <span>ExternalLink</span>,
+}));
+
+const buildSnapshot = (overrides: Partial<StacksTxStatusSnapshot> = {}): StacksTxStatusSnapshot => ({
+  state: 'pending',
+  txStatusRaw: 'pending',
+  message: 'Transaction in Stacks mempool — confirming with Bitcoin...',
+  txId: '0xabc',
+  elapsedMs: 120000,
+  estimatedMs: 750000,
+  remainingMs: 630000,
+  progressPercent: 16,
+  microblockAnchorTime: null,
+  hasTerminalError: false,
+  isPolling: true,
+  pendingPhase: 'mempool',
+  notFoundGraceRemainingMs: null,
+  averageBlockTimeMinutes: 12.5,
+  ...overrides,
+});
+
+describe('StacksTxStatusPanel', () => {
+  it('renders pending status with average-time progress details', () => {
+    render(<StacksTxStatusPanel snapshot={buildSnapshot()} />);
+
+    expect(screen.getByText('Transaction in Stacks mempool — confirming with Bitcoin...')).toBeInTheDocument();
+    expect(screen.getByText(/average Stacks block time/i)).toBeInTheDocument();
+    expect(screen.getByText(/Approx. 11 min remaining/i)).toBeInTheDocument();
+  });
+
+  it('shows propagation grace text for temporary 404 states', () => {
+    render(
+      <StacksTxStatusPanel
+        snapshot={buildSnapshot({
+          txStatusRaw: 'not_found',
+          message: 'Transaction submitted — waiting for indexer propagation...',
+          pendingPhase: 'propagation',
+          notFoundGraceRemainingMs: 59 * 60 * 1000,
+        })}
+      />
+    );
+
+    expect(screen.getByText(/waiting for indexer propagation/i)).toBeInTheDocument();
+    expect(screen.getByText(/only mark this as not found/i)).toBeInTheDocument();
+  });
+
+  it('renders confirmed state', () => {
+    render(
+      <StacksTxStatusPanel
+        snapshot={buildSnapshot({
+          state: 'success',
+          txStatusRaw: 'success',
+          message: 'Confirmed',
+          isPolling: false,
+        })}
+      />
+    );
+
+    expect(screen.getByText('Confirmed')).toBeInTheDocument();
+  });
+
+  it('renders rejection state message', () => {
+    render(
+      <StacksTxStatusPanel
+        snapshot={buildSnapshot({
+          state: 'abort_by_response',
+          txStatusRaw: 'abort_by_response',
+          message: 'Transaction rejected — check post-conditions',
+          hasTerminalError: true,
+          isPolling: false,
+        })}
+      />
+    );
+
+    expect(screen.getByText('Transaction rejected — check post-conditions')).toBeInTheDocument();
+  });
+
+  it('renders microblock anchor label when available', () => {
+    render(
+      <StacksTxStatusPanel
+        snapshot={buildSnapshot({
+          microblockAnchorTime: 1710000000,
+        })}
+      />
+    );
+
+    expect(screen.getByText(/Microblock anchor time/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/WithdrawCard.test.tsx
+++ b/frontend/src/components/__tests__/WithdrawCard.test.tsx
@@ -170,6 +170,34 @@ describe('WithdrawCard Component', () => {
       });
     });
 
+    it('keeps tx pending when status is temporary not_found within grace period', async () => {
+      mockWithdraw.mockResolvedValue({ success: true, txId: '0xabc' });
+      mockUseStacksTxStatus.mockReturnValue(buildTxSnapshot({
+        state: 'pending',
+        txStatusRaw: 'not_found',
+        pendingPhase: 'propagation',
+        message: 'Transaction submitted — waiting for indexer propagation...',
+        txId: '0xabc',
+        hasTerminalError: false,
+        isPolling: true,
+      }));
+
+      const user = userEvent.setup();
+      render(<WithdrawCard />);
+
+      const input = screen.getByPlaceholderText('0.00');
+      await user.type(input, '5');
+
+      const submitBtn = screen.getByRole('button', { name: /Withdraw STX/i });
+      await user.click(submitBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/waiting for indexer propagation/i)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/See transaction details below./i)).not.toBeInTheDocument();
+    });
+
     it('disables submit when no amount entered', () => {
       render(<WithdrawCard />);
       const submitBtn = screen.getByRole('button', { name: /Withdraw STX/i });

--- a/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
@@ -59,6 +59,25 @@ describe('useStacksTxStatus', () => {
     await waitFor(() => {
       expect(result.current.state).toBe('pending');
       expect(result.current.hasTerminalError).toBe(false);
+      expect(result.current.pendingPhase).toBe('propagation');
+      expect(result.current.message).toContain('waiting for indexer propagation');
+      expect(result.current.notFoundGraceRemainingMs).toBeTypeOf('number');
+    });
+  });
+
+  it('stores average block timing metadata for progress calculation', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ tx_id: '0xabc', tx_status: 'pending' }),
+    });
+
+    const { result } = renderHook(() => useStacksTxStatus('0xabc'));
+
+    await waitFor(() => {
+      expect(result.current.state).toBe('pending');
+      expect(result.current.averageBlockTimeMinutes).toBe(12.5);
+      expect(result.current.estimatedMs).toBe(750000);
     });
   });
 
@@ -99,5 +118,35 @@ describe('useStacksTxStatus', () => {
       expect(result.current.state).toBe('pending');
       expect(result.current.microblockAnchorTime).toBe(1710000000);
     });
+  });
+
+  it('continues polling every 30 seconds while pending', async () => {
+    vi.useFakeTimers();
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ tx_id: '0xabc', tx_status: 'pending' }),
+    });
+
+    renderHook(() => useStacksTxStatus('0xabc'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
@@ -120,8 +120,9 @@ describe('useStacksTxStatus', () => {
     });
   });
 
-  it('continues polling every 30 seconds while pending', async () => {
-    vi.useFakeTimers();
+  it('configures 30-second polling without terminal timeout behavior', async () => {
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
 
     mockFetch.mockResolvedValue({
       ok: true,
@@ -129,29 +130,24 @@ describe('useStacksTxStatus', () => {
       json: async () => ({ tx_id: '0xabc', tx_status: 'pending' }),
     });
 
-    renderHook(() => useStacksTxStatus('0xabc'));
+    const { unmount } = renderHook(() => useStacksTxStatus('0xabc'));
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
     });
 
-    await vi.advanceTimersByTimeAsync(30_000);
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-    });
-
-    await vi.advanceTimersByTimeAsync(30_000);
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(3);
-    });
-
-    vi.useRealTimers();
+    const clearCallsBeforeUnmount = clearIntervalSpy.mock.calls.length;
+    unmount();
+    expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(clearCallsBeforeUnmount);
   });
 
   it('keeps propagation messaging after temporary upstream API failure', async () => {
-    vi.useFakeTimers();
+    const setIntervalSpy = vi
+      .spyOn(window, 'setInterval')
+      .mockImplementation((() => 1 as unknown as number) as typeof window.setInterval);
+
+    vi.spyOn(window, 'clearInterval').mockImplementation(() => undefined);
 
     mockFetch
       .mockResolvedValueOnce({
@@ -168,19 +164,26 @@ describe('useStacksTxStatus', () => {
     const { result } = renderHook(() => useStacksTxStatus('0xabc'));
 
     await waitFor(() => {
-      expect(result.current.pendingPhase).toBe('propagation');
-      expect(result.current.message).toContain('waiting for indexer propagation');
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    await vi.advanceTimersByTimeAsync(30_000);
+    await waitFor(() => {
+      expect(result.current.txStatusRaw).toBe('not_found');
+      expect(result.current.pendingPhase).toBe('propagation');
+      expect(result.current.message).toContain('waiting for indexer propagation');
+    });
+
+    const intervalCallback = setIntervalSpy.mock.calls[0]?.[0];
+    expect(typeof intervalCallback).toBe('function');
+
+    if (typeof intervalCallback === 'function') {
+      intervalCallback();
+    }
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(result.current.pendingPhase).toBe('propagation');
       expect(result.current.message).toContain('waiting for indexer propagation');
     });
-
-    vi.useRealTimers();
   });
 });

--- a/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
@@ -149,4 +149,38 @@ describe('useStacksTxStatus', () => {
 
     vi.useRealTimers();
   });
+
+  it('keeps propagation messaging after temporary upstream API failure', async () => {
+    vi.useFakeTimers();
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'not found' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'unavailable' }),
+      });
+
+    const { result } = renderHook(() => useStacksTxStatus('0xabc'));
+
+    await waitFor(() => {
+      expect(result.current.pendingPhase).toBe('propagation');
+      expect(result.current.message).toContain('waiting for indexer propagation');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result.current.pendingPhase).toBe('propagation');
+      expect(result.current.message).toContain('waiting for indexer propagation');
+    });
+
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/hooks/useStacksTxStatus.ts
+++ b/frontend/src/hooks/useStacksTxStatus.ts
@@ -109,6 +109,7 @@ export const useStacksTxStatus = (txId: string): StacksTxStatusSnapshot => {
     const apiEndpoint = import.meta.env.VITE_STACKS_API_URL || DEFAULT_API_ENDPOINT;
     const startedAt = Date.now();
     const estimatedMs = DEFAULT_BLOCK_TIME_MINUTES * 60 * 1000;
+    let lastObservedTxStatus: string | null = 'pending';
     let intervalId: number | null = null;
 
     const updateSnapshot = (
@@ -154,7 +155,7 @@ export const useStacksTxStatus = (txId: string): StacksTxStatusSnapshot => {
       }
     };
 
-    updateSnapshot('pending', 'pending');
+    updateSnapshot('pending', lastObservedTxStatus);
 
     const poll = async () => {
       try {
@@ -167,21 +168,23 @@ export const useStacksTxStatus = (txId: string): StacksTxStatusSnapshot => {
             return;
           }
 
+          lastObservedTxStatus = 'not_found';
           updateSnapshot('pending', 'not_found');
           return;
         }
 
         if (!response.ok) {
-          updateSnapshot('pending', 'pending');
+          updateSnapshot('pending', lastObservedTxStatus);
           return;
         }
 
         const data = (await response.json()) as HiroTxResponse;
         const nextState = getMappedState(data.tx_status);
+        lastObservedTxStatus = data.tx_status;
 
         updateSnapshot(nextState, data.tx_status, data.microblock_anchor_time);
       } catch {
-        updateSnapshot('pending', 'pending');
+        updateSnapshot('pending', lastObservedTxStatus);
       }
     };
 

--- a/frontend/src/hooks/useStacksTxStatus.ts
+++ b/frontend/src/hooks/useStacksTxStatus.ts
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
-import { HiroTxResponse, StacksTxStatusSnapshot, StacksTxStatusState } from '../types/txStatus';
+import {
+  HiroTxResponse,
+  StacksPendingPhase,
+  StacksTxStatusSnapshot,
+  StacksTxStatusState,
+} from '../types/txStatus';
 
 const POLL_INTERVAL_MS = 30_000;
 const NOT_FOUND_GRACE_MS = 60 * 60 * 1000;
@@ -33,6 +38,22 @@ const getMappedState = (txStatusRaw: string | null): StacksTxStatusState => {
       return 'pending';
   }
 };
+
+const getPendingPhase = (txStatusRaw: string | null): StacksPendingPhase => {
+  if (txStatusRaw === 'not_found') {
+    return 'propagation';
+  }
+
+  return 'mempool';
+};
+
+const mapLifecycle = (txStatusRaw: string | null): {
+  state: StacksTxStatusState;
+  pendingPhase: StacksPendingPhase;
+} => ({
+  state: getMappedState(txStatusRaw),
+  pendingPhase: getPendingPhase(txStatusRaw),
+});
 
 const getMappedMessage = (state: StacksTxStatusState): string => {
   switch (state) {
@@ -90,6 +111,8 @@ export const useStacksTxStatus = (txId: string): StacksTxStatusSnapshot => {
         return;
       }
 
+      const lifecycle = mapLifecycle(txStatusRaw);
+
       const nextSnapshot: StacksTxStatusSnapshot = {
         state,
         txStatusRaw,
@@ -102,6 +125,7 @@ export const useStacksTxStatus = (txId: string): StacksTxStatusSnapshot => {
         microblockAnchorTime: microblockAnchorTime ?? null,
         hasTerminalError: state === 'abort_by_response' || state === 'not_found',
         isPolling: state === 'pending',
+        pendingPhase: lifecycle.pendingPhase,
       };
 
       setSnapshot(nextSnapshot);

--- a/frontend/src/hooks/useStacksTxStatus.ts
+++ b/frontend/src/hooks/useStacksTxStatus.ts
@@ -8,10 +8,11 @@ import {
 
 const POLL_INTERVAL_MS = 30_000;
 const NOT_FOUND_GRACE_MS = 60 * 60 * 1000;
-const DEFAULT_BLOCK_TIME_MINUTES = 10;
+const DEFAULT_BLOCK_TIME_MINUTES = 12.5;
 const DEFAULT_API_ENDPOINT = 'https://api.testnet.hiro.so';
 
 const DEFAULT_MESSAGE = 'Transaction in Stacks mempool — confirming with Bitcoin...';
+const PROPAGATION_MESSAGE = 'Transaction submitted — waiting for indexer propagation...';
 
 const INITIAL_SNAPSHOT: StacksTxStatusSnapshot = {
   state: 'idle',
@@ -25,6 +26,9 @@ const INITIAL_SNAPSHOT: StacksTxStatusSnapshot = {
   microblockAnchorTime: null,
   hasTerminalError: false,
   isPolling: false,
+  pendingPhase: 'mempool',
+  notFoundGraceRemainingMs: null,
+  averageBlockTimeMinutes: DEFAULT_BLOCK_TIME_MINUTES,
 };
 
 const getMappedState = (txStatusRaw: string | null): StacksTxStatusState => {
@@ -55,7 +59,11 @@ const mapLifecycle = (txStatusRaw: string | null): {
   pendingPhase: getPendingPhase(txStatusRaw),
 });
 
-const getMappedMessage = (state: StacksTxStatusState): string => {
+const getMappedMessage = (
+  state: StacksTxStatusState,
+  pendingPhase: StacksPendingPhase,
+  notFoundGraceRemainingMs: number | null
+): string => {
   switch (state) {
     case 'success':
       return 'Confirmed';
@@ -64,6 +72,10 @@ const getMappedMessage = (state: StacksTxStatusState): string => {
     case 'not_found':
       return 'Transaction not found after 60 minutes. Confirm the tx ID in the explorer.';
     case 'pending':
+      if (pendingPhase === 'propagation' && notFoundGraceRemainingMs !== null) {
+        return PROPAGATION_MESSAGE;
+      }
+
       return DEFAULT_MESSAGE;
     default:
       return '';
@@ -112,12 +124,16 @@ export const useStacksTxStatus = (txId: string): StacksTxStatusSnapshot => {
       }
 
       const lifecycle = mapLifecycle(txStatusRaw);
+      const notFoundGraceRemainingMs =
+        state === 'pending' && txStatusRaw === 'not_found'
+          ? Math.max(NOT_FOUND_GRACE_MS - elapsedMs, 0)
+          : null;
 
       const nextSnapshot: StacksTxStatusSnapshot = {
         state,
         txStatusRaw,
         txId: normalizedTxId,
-        message: getMappedMessage(state),
+        message: getMappedMessage(state, lifecycle.pendingPhase, notFoundGraceRemainingMs),
         elapsedMs: progress.elapsedMs,
         estimatedMs,
         remainingMs: progress.remainingMs,
@@ -126,6 +142,8 @@ export const useStacksTxStatus = (txId: string): StacksTxStatusSnapshot => {
         hasTerminalError: state === 'abort_by_response' || state === 'not_found',
         isPolling: state === 'pending',
         pendingPhase: lifecycle.pendingPhase,
+        notFoundGraceRemainingMs,
+        averageBlockTimeMinutes: DEFAULT_BLOCK_TIME_MINUTES,
       };
 
       setSnapshot(nextSnapshot);

--- a/frontend/src/types/txStatus.ts
+++ b/frontend/src/types/txStatus.ts
@@ -1,5 +1,7 @@
 export type StacksTxStatusState = 'idle' | 'pending' | 'success' | 'abort_by_response' | 'not_found';
 
+export type StacksPendingPhase = 'mempool' | 'propagation';
+
 export interface StacksTxStatusSnapshot {
   state: StacksTxStatusState;
   txStatusRaw: string | null;
@@ -12,6 +14,9 @@ export interface StacksTxStatusSnapshot {
   microblockAnchorTime?: number | null;
   hasTerminalError: boolean;
   isPolling: boolean;
+  pendingPhase?: StacksPendingPhase;
+  notFoundGraceRemainingMs?: number | null;
+  averageBlockTimeMinutes?: number;
 }
 
 export interface HiroTxResponse {


### PR DESCRIPTION
## Summary
- switch transaction confirmation polling to Hiro `GET /extended/v1/tx/{txId}` with a 30-second interval and no fixed timeout cap
- map Stacks lifecycle states into explicit UX messaging for `pending`, `success`, `abort_by_response`, and delayed indexer propagation
- keep `not_found` non-terminal for 60 minutes to prevent false failure states while transactions are still propagating
- surface average Stacks block-time progress guidance and optional microblock anchor time context in the status panel
- add regression coverage for hook lifecycle transitions and transaction cards to guard against timeout regressions

## Testing
- `npm run test -- src/hooks/__tests__/useStacksTxStatus.test.ts src/components/__tests__/StacksTxStatusPanel.test.tsx src/components/__tests__/DepositCard.test.tsx src/components/__tests__/WithdrawCard.test.tsx src/components/__tests__/BorrowCard.test.tsx src/components/__tests__/RepayCard.test.tsx`
- `npm run test`
