### PR TITLE
fix: resolve frontend typescript compilation errors

### DIFF
--- a/frontend/src/components/__tests__/HealthMonitor.test.tsx
+++ b/frontend/src/components/__tests__/HealthMonitor.test.tsx
@@ -10,8 +10,20 @@ const { mockOracleSanityState, mockVaultState } = vi.hoisted(() => ({
   mockOracleSanityState: { current: { warning: false, deviation: 0, marketRate: null as number | null } },
   mockVaultState: { 
     deposit: null, 
-    loan: null, 
-    healthFactor: null 
+    loan: null as null | {
+      amountSTX: number;
+      collateralAmountSTX: number;
+      status: string;
+      termEnd: number;
+      interestRatePercent: number;
+      startTimestamp: number;
+    },
+    healthFactor: null as null | {
+      healthFactorPercent: number;
+      collateralValueUSD: number;
+      debtValueUSD: number;
+      stxPriceUSD: number;
+    },
   },
 }));
 

--- a/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useStacksTxStatus.test.ts
@@ -146,7 +146,7 @@ describe('useStacksTxStatus', () => {
   it('keeps propagation messaging after temporary upstream API failure', async () => {
     const setIntervalSpy = vi
       .spyOn(window, 'setInterval')
-      .mockImplementation((() => 1 as unknown as number) as typeof window.setInterval);
+      .mockImplementation((() => 1) as unknown as typeof window.setInterval);
 
     vi.spyOn(window, 'clearInterval').mockImplementation(() => undefined);
 


### PR DESCRIPTION
This PR fixes TypeScript strict-mode compilation errors in the frontend test files that were causing Vercel production deployment builds to fail.

### Changes
- **HealthMonitor.test.tsx**: Widened types for the mocked state fields (loan and healthFactor) in mockVaultState. Previously, these fields were inferred as 
ull, causing compilation errors when test cases attempted to assign object literals to them.
- **useStacksTxStatus.test.ts**: Adjusted setInterval spy return type mock/casting to resolve type mismatch errors under strict type checking.